### PR TITLE
new layout pageCenter #32

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,3 +33,4 @@
 @import './layouts/ly-imgContent.css';
 @import './layouts/ly-form.css';
 @import './layouts/ly-columns.css';
+@import './layouts/ly-pageCenter.css';

--- a/src/layouts/ly-pageCenter.css
+++ b/src/layouts/ly-pageCenter.css
@@ -1,0 +1,22 @@
+/* Common pattern of a content centered in the page */
+
+.ola_ly-pageCenter {
+    display: grid;
+    grid-template-columns: 1fr minmax(0, var(--size-12)) 1fr;
+    grid-column-gap: var(--column-gap);
+    grid-row-gap: var(--row-gap);
+    min-height: 100%;
+    box-sizing: border-box;
+    align-content: center;
+
+    & > * {
+        grid-column: 2 / span 1;
+    }
+
+    & > *.is-fullwidth {
+        grid-column: 1 / -1;
+        max-width: max-content;
+        min-width: var(--size-12);
+        justify-self: center;
+    }
+}

--- a/stories/layout.stories.js
+++ b/stories/layout.stories.js
@@ -9,8 +9,27 @@ import {
   ButtonGroup,
   Input,
   Field,
-  FieldDescription,
+  CheckArea,
 } from '../dist'
+
+const random_option_values_with_description = [
+  {
+    label: '<strong>Test 1</strong>Lorem ipsum dolor sit amet.',
+    value: 'test1'
+  },
+  {
+    label: '<strong>Test 2</strong>Lorem ipsum dolor sit amet.',
+    value: 'test2'
+  },
+  {
+    label: '<strong>Test 3</strong>Lorem ipsum dolor sit amet.',
+    value: 'test3'
+  },
+  {
+    label: '<strong>Test 4</strong>Lorem ipsum dolor sit amet.',
+    value: 'test4'
+  }
+]
 
 storiesOf('Layout', module)
   .addDecorator(withInfo)
@@ -96,4 +115,32 @@ storiesOf('Layout', module)
             </div>
         </PanelContent>
     </Panel>
+    ))
+  .add('ola_ly-pageCenter', () => (
+      <section className="ola_ly-pageCenter">
+          <header>
+              <h1 className="ola-title">Welcome to this page</h1>
+              <p className="ola-callout ola-gray">This is a introductory text of this process</p>
+          </header>
+
+          <div>
+              <Field id="field-name2" label="Email">
+                  <Input type="email" placeholder="name@example.com" />
+              </Field>
+
+              <Field id="field-password2" label="Password">
+                  <Input type="password" placeholder="Super secret" />
+              </Field>
+          </div>
+
+          <div className="is-fullwidth">
+            <CheckArea htmlOptions options={random_option_values_with_description} variant="column" />
+          </div>
+
+          <footer>
+            <ButtonGroup>
+              <Button href="#" variant="primary">Continue</Button>
+            </ButtonGroup>
+          </footer>
+      </section>
     ))


### PR DESCRIPTION
@pedroparra Added `pageCenter` layout, that is much more simpler than expected, consisting in just one class `.ola_ly-pageCenter` and the modifier `.is-fullwidth`. It's not necesary to define the header and footer that we talk before . Added also an example in the storybook.

Note: do not merge this until v1.2 is released.