### PR TITLE
Changed TableCell to make it more scalable

### DIFF
--- a/src/Table/Cell.js
+++ b/src/Table/Cell.js
@@ -2,30 +2,27 @@ import React from 'react'
 import {default as PT} from 'prop-types'
 import cx from 'classnames'
 
-const TableCell = ({ variant, align, numeric, extraClass, children, ...props }) => {
-  const Component = (variant === 'header') ? 'th' : 'td'
+const TableCell = ({ header, variant, extraClass, children, ...props }) => {
+  const Component = header ? 'th' : 'td'
   return (
-    <Component className={cx(numeric && 'ola-numeric', align && align !== 'left' && `ola-${align}`, extraClass)} {...props}>
+    <Component className={cx('ola_tableCell', `is-${variant}`, extraClass)} {...props}>
       {children}
     </Component>
   )
 }
 
 TableCell.defaultProps = {
-  align: 'left',
-  numeric: false,
-  variant: 'body'
+  variant: 'left',
+  header: false
 }
 
 TableCell.propTypes = {
   /** Extra className */
   extraClass: PT.string,
-  /** Content align */
-  align: PT.oneOf(['left', 'center', 'right']),
-  /** Is numeric content */
-  numeric: PT.bool,
-  /** Variant */
-  variant: PT.oneOf(['header', 'body']),
+  /** Content type */
+  variant: PT.oneOf(['left', 'center', 'right', 'numeric', 'action', 'check']),
+  /** Whether is a header */
+  header: PT.bool,
   /** Childen nodes */
   children: PT.oneOfType([
     PT.string,

--- a/src/Table/Row.js
+++ b/src/Table/Row.js
@@ -6,7 +6,7 @@ import TableCell from './Cell.js'
 const TableRow = ({ extraClass, check, children, checked, ...props }) => {
   return (
     <tr className={cx('ola_tableRow', {'is-selectable': check, 'is-checked': checked}, extraClass)} {...props}>
-      {check && (<TableCell extraClass="ola_tableRow-check">{check}</TableCell>)}
+      {check && (<TableCell variant="check">{check}</TableCell>)}
       {children}
     </tr>
   )

--- a/src/Table/__snapshots__/test.js.snap
+++ b/src/Table/__snapshots__/test.js.snap
@@ -17,7 +17,7 @@ exports[`Add caption 1`] = `
 
 exports[`Align center Cell 1`] = `
 <td
-  className="ola-center"
+  className="ola_tableCell is-center"
 >
   Test content
 </td>
@@ -37,14 +37,14 @@ exports[`Can be stiky 1`] = `
 
 exports[`ColSpan Cell 1`] = `
 <td
-  className=""
+  className="ola_tableCell is-left"
   colSpan={8}
 />
 `;
 
 exports[`Default Cell 1`] = `
 <td
-  className=""
+  className="ola_tableCell is-left"
 >
   Test content
 </td>
@@ -64,13 +64,13 @@ exports[`Default Table 1`] = `
 
 exports[`Empty Cell 1`] = `
 <td
-  className=""
+  className="ola_tableCell is-left"
 />
 `;
 
 exports[`Header Cell 1`] = `
 <th
-  className=""
+  className="ola_tableCell is-left"
 >
   Content
 </th>
@@ -78,7 +78,7 @@ exports[`Header Cell 1`] = `
 
 exports[`Numeric Cell 1`] = `
 <td
-  className="ola-numeric"
+  className="ola_tableCell is-numeric"
 >
   8
 </td>
@@ -89,7 +89,7 @@ exports[`Table row 1`] = `
   className="ola_tableRow is-selectable"
 >
   <td
-    className="ola_tableRow-check"
+    className="ola_tableCell is-check"
   >
     <label
       className="ola_check"
@@ -104,7 +104,7 @@ exports[`Table row 1`] = `
     </label>
   </td>
   <td
-    className=""
+    className="ola_tableCell is-left"
   >
     First column
   </td>

--- a/src/Table/stories.js
+++ b/src/Table/stories.js
@@ -13,7 +13,7 @@ const data = [
     links: '999999',
     popularity: 'hight',
     checked: false,
-    action: <Button>Edit</Button>
+    action: <Button>Change column</Button>
   },
   {
     title: 'Page title test 2',
@@ -27,7 +27,7 @@ const data = [
     links: '2354689',
     popularity: 'hight',
     checked: false,
-    action: <Button>Edit</Button>
+    action: <Button>Other action</Button>
   },
   {
     title: 'Page title test 4',
@@ -44,20 +44,18 @@ storiesOf('Table')
       <Table caption="Superheros and sidekicks" stiky>
         <thead>
           <tr>
-            <TableCell variant="header"></TableCell>
-            <TableCell variant="header">Page</TableCell>
-            <TableCell variant="header" align="right">Incoming links</TableCell>
-            <TableCell variant="header" align="center">Popularity</TableCell>
-            <TableCell variant="header" align="center">Actions</TableCell>
+            <TableCell header variant="check"></TableCell>
+            <TableCell header>Page</TableCell>
+            <TableCell header variant="numeric">Incoming links</TableCell>
+            <TableCell header variant="center">Popularity</TableCell>
           </tr>
         </thead>
         <tbody>
           { data.map( (row, idx) => (
             <TableRow key={idx} check={<Check type="checkbox" name="foo" checked={row.checked} />} checked={row.checked}>
               <TableCell>{row.title}</TableCell>
-              <TableCell numeric>{row.links}</TableCell>
-              <TableCell align="center">{row.popularity}</TableCell>
-              <TableCell align="center">{row.action}</TableCell>
+              <TableCell variant="numeric">{row.links}</TableCell>
+              <TableCell variant="center">{row.popularity}</TableCell>
             </TableRow>
           ) ) }
         </tbody>
@@ -65,24 +63,26 @@ storiesOf('Table')
     </figure>
   ))
   .add('Default', () => (
-    <Table caption="Superheros and sidekicks" stiky>
-      <thead>
-        <tr>
-          <TableCell variant="header">Your current page title</TableCell>
-          <TableCell variant="header" align="right">Incoming links</TableCell>
-          <TableCell variant="header" align="center">Popularity</TableCell>
-          <TableCell variant="header" align="center">Actions</TableCell>
-        </tr>
-      </thead>
-      <tbody>
-        { data.map( (row, idx) => (
-          <tr key={idx}>
-            <TableCell>{row.title}</TableCell>
-            <TableCell numeric>{row.links}</TableCell>
-            <TableCell align="center">{row.popularity}</TableCell>
-            <TableCell align="center">{row.action}</TableCell>
+    <figure>
+      <Table caption="Superheros and sidekicks" stiky>
+        <thead>
+          <tr>
+            <TableCell header>Your current page title</TableCell>
+            <TableCell header variant="right">Incoming links</TableCell>
+            <TableCell header variant="center">Popularity</TableCell>
+            <TableCell header variant="action">Actions</TableCell>
           </tr>
-        ) ) }
-      </tbody>
-    </Table>
+        </thead>
+        <tbody>
+          { data.map( (row, idx) => (
+            <tr key={idx}>
+              <TableCell>{row.title}</TableCell>
+              <TableCell variant="numeric">{row.links}</TableCell>
+              <TableCell variant="center">{row.popularity}</TableCell>
+              <TableCell variant="action">{row.action}</TableCell>
+            </tr>
+          ) ) }
+        </tbody>
+      </Table>
+    </figure>
   ))

--- a/src/Table/style.css
+++ b/src/Table/style.css
@@ -26,10 +26,6 @@
         border-top: solid 1px var(--gray-xlight);
     }
 
-    & :matches(th, td) + :matches(th, td) {
-        padding-left: var(--size-8);
-    }
-
     & thead {
         & th {
             white-space: nowrap;
@@ -65,8 +61,39 @@
         background-color: var(--gray-xlight);
         color: var(--black);
     }
+}
 
-    & .ola_tableRow-check {
-        padding-left: var(--size-4);
+.ola_tableCell {
+    &.is-left {
+        text-align: left;
     }
+    &.is-right {
+        text-align: right;
+    }
+    &.is-center {
+        text-align: center;
+    }
+    &.is-numeric {
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+    }
+    &.is-action {
+        text-align: right;
+        padding-right: 0;
+    }
+    &.is-check {
+        padding-left: var(--size-4);
+        width: var(--size-7);
+
+        & + .ola_tableCell {
+            padding-left: var(--size-4);
+        }
+    }
+
+    & + .ola_tableCell {
+        padding-left: var(--size-8);
+    }
+}
+th.ola_tableCell.is-action {
+    padding-right: var(--size-7);
 }

--- a/src/Table/test.js
+++ b/src/Table/test.js
@@ -67,7 +67,7 @@ it('Default Cell', () => {
 it('Header Cell', () => {
   const tree = renderer
     .create(
-      <TableCell variant="header">Content</TableCell>
+      <TableCell header>Content</TableCell>
     )
     .toJSON()
 
@@ -97,7 +97,7 @@ it('ColSpan Cell', () => {
 it('Numeric Cell', () => {
   const tree = renderer
     .create(
-      <TableCell numeric>8</TableCell>
+      <TableCell variant="numeric">8</TableCell>
     )
     .toJSON()
 
@@ -107,7 +107,7 @@ it('Numeric Cell', () => {
 it('Align center Cell', () => {
   const tree = renderer
     .create(
-      <TableCell align="center">Test content</TableCell>
+      <TableCell variant="center">Test content</TableCell>
     )
     .toJSON()
 


### PR DESCRIPTION
Changed TableCell according to #37

- Added the following variants
  - `left` (by default) align the content to the left
  - `center` center the content
  - `right` alignt the content to the right
  - `numeric` The content is numeric (align to the right and use fixed-width numbers
  - `action` The content is a button
  - `check` The content is a check (radio or box)
- Removed align (use variants instead)
- Added the booleant property `header` to define the cell as a th or td (and removed the header variant)
- Some css fixes and adjustments