### PR TITLE
Removed dangerouslySetInnerHTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Component `Switch` use `children` to define the label content, instead `label` and `htmlLabel` properties. [#28]
 - The signature of `TableCell` component has changed. See [#37] and [#65] for more info.
+- Removed the properties `htmlTitle` and `htmlIntro` in `ModalHeader`. Now `title` and `intro` accept not only strings but also nodes as values [#28]
 
 ### Fixed
 - Removed `display:flex` to Check areas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.4.0] - Unreleased
+### Added
+- Property `extraClass` to `Switch`, `ModalHeader`, `PanelHeader`.
+
 ### Changed
-- Component `Switch` use `children` to define the label content, instead `label` and `htmlLabel` properties. [#28]
+- `Switch`: From now use `children` to define the label content, instead `label` and `htmlLabel` properties. [#28]
+- `ProgressBar`: From now use `children` to define the description, instead `description` and `htmlDescription` properties. [#28]
 - The signature of `TableCell` component has changed. See [#37] and [#65] for more info.
-- Removed the properties `htmlTitle` and `htmlIntro` in `ModalHeader`. Now `title` and `intro` accept not only strings but also nodes as values [#28]
+- `ModalHeader`: Removed the properties `htmlTitle` and `htmlIntro`. From now, `title` and `intro` accept strings and nodes as values [#28]
+- `PanelHeader`: Removed the properties `htmlTitle` and `htmlIntro`. From now, `title` and `intro` accept strings and nodes as values [#28]
+- `PanelContent`: Removed the property `htmlTitle`. From now `title` accepts strings and nodes as values [#28]
+- `Metric`: Removed the property `htmlFooter`. From now `footer` accepts strings and nodes as values [#28]
+- `Task`: Removed the property `htmlTitle`. From now `title` accepts strings and nodes as values [#28]
 
 ### Fixed
 - Removed `display:flex` to Check areas.
@@ -188,7 +196,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#56]: https://github.com/marketgoo/Ola/issues/56
 [#65]: https://github.com/marketgoo/Ola/issues/65
 
-[Unreleased]: https://github.com/marketgoo/Ola/compare/v0.3.0...HEAD
+[0.4.0]: https://github.com/marketgoo/Ola/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/marketgoo/Ola/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/marketgoo/Ola/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/marketgoo/Ola/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Component `Switch` use `children` to define the label content, instead `label` and `htmlLabel` properties. [#28]
+- The signature of `TableCell` component has changed. See [#37] and [#65] for more info.
+
 ### Fixed
 - Removed `display:flex` to Check areas.
 - Decrease padding in Check areas in columns.
@@ -165,12 +169,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#20]: https://github.com/marketgoo/Ola/issues/20
 [#21]: https://github.com/marketgoo/Ola/issues/21
 [#23]: https://github.com/marketgoo/Ola/issues/23
+[#28]: https://github.com/marketgoo/Ola/issues/28
 [#30]: https://github.com/marketgoo/Ola/issues/30
 [#32]: https://github.com/marketgoo/Ola/issues/32
 [#33]: https://github.com/marketgoo/Ola/issues/33
 [#34]: https://github.com/marketgoo/Ola/issues/34
 [#35]: https://github.com/marketgoo/Ola/issues/35
 [#36]: https://github.com/marketgoo/Ola/issues/36
+[#37]: https://github.com/marketgoo/Ola/issues/37
 [#39]: https://github.com/marketgoo/Ola/issues/39
 [#40]: https://github.com/marketgoo/Ola/issues/40
 [#41]: https://github.com/marketgoo/Ola/issues/41
@@ -179,6 +185,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#47]: https://github.com/marketgoo/Ola/issues/47
 [#54]: https://github.com/marketgoo/Ola/issues/54
 [#56]: https://github.com/marketgoo/Ola/issues/56
+[#65]: https://github.com/marketgoo/Ola/issues/65
 
 [Unreleased]: https://github.com/marketgoo/Ola/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/marketgoo/Ola/compare/v0.2.2...v0.3.0

--- a/src/Metric/index.js
+++ b/src/Metric/index.js
@@ -10,10 +10,6 @@ const defaultIcons = {
   negative: 'error'
 }
 
-const MetricFooter = ({ footer, htmlFooter }) => {
-  return footer && ( htmlFooter ? <p className="ola_metric-footer" dangerouslySetInnerHTML={{__html: footer}} /> : <p className="ola_metric-footer">{footer}</p>)
-}
-
 const MetricValue = ({busy=false, variant, valueIcon, children}) => {
   return (
     <strong className="ola_metric-value">
@@ -25,7 +21,7 @@ const MetricValue = ({busy=false, variant, valueIcon, children}) => {
   )
 }
 
-const Metric = ({ title, value, description, variant, valueIcon, busy, extraClass, footer, htmlFooter, ...props }) => {
+const Metric = ({ title, value, description, variant, valueIcon, busy, extraClass, footer, ...props }) => {
   return (
     <div className={cx('ola_metric', variant && `is-${variant}`, busy && 'is-busy', footer && 'is-centered', extraClass)} {...props}>
       <strong className="ola_metric-title">{title}</strong>
@@ -33,7 +29,7 @@ const Metric = ({ title, value, description, variant, valueIcon, busy, extraClas
       <MetricValue busy={busy} variant={variant} valueIcon={valueIcon}>
         {value}
       </MetricValue>
-      <MetricFooter footer={footer} htmlFooter={htmlFooter} />
+      { footer && <p className="ola_metric-footer">{footer}</p> }
     </div>
   )
 }
@@ -46,8 +42,7 @@ Metric.defaultProps = {
   variant: null,
   valueIcon: false,
   busy: false,
-  footer: null,
-  htmlFooter: false
+  footer: null
 }
 
 Metric.propTypes = {
@@ -66,9 +61,11 @@ Metric.propTypes = {
   /** Busy state */
   busy: PT.bool,
   /** Footer */
-  footer: PT.string,
-  /** Footer support HTML tags */
-  htmlFooter: PT.bool
+  footer: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ])
 }
 
 export default Metric

--- a/src/Metric/stories.js
+++ b/src/Metric/stories.js
@@ -29,8 +29,7 @@ storiesOf('Metric')
     <figure>
       <Metric
         title="Do you have a blog?"
-        footer={'We found a Blog at <a href="#">http:blog.example.com</a>'}
-        htmlFooter
+        footer={<>We found a Blog at <a href="#">http:blog.example.com</a></>}
         value="Yes"
         variant="positive"/>
     </figure>

--- a/src/Modal/Footer.js
+++ b/src/Modal/Footer.js
@@ -15,6 +15,7 @@ ModalFooter.propTypes = {
   extraClass: PT.string,
   /** Childen nodes */
   children: PT.oneOfType([
+    PT.string,
     PT.arrayOf(PT.node),
     PT.node
   ]).isRequired

--- a/src/Modal/Header.js
+++ b/src/Modal/Header.js
@@ -2,46 +2,38 @@ import React from 'react'
 import {default as PT} from 'prop-types'
 import cx from 'classnames'
 
-const ModalTitle = ({ title, htmlTitle=false }) => {
-  return htmlTitle ?
-    <h2 className="ola_modal-title" dangerouslySetInnerHTML={{__html: title}} /> :
-    <h2 className="ola_modal-title">{title}</h2>
-}
-
-const ModalIntro = ({ intro, htmlIntro=false }) => {
-  return htmlIntro ?
-    <p className="ola_modal-intro" dangerouslySetInnerHTML={{__html: intro}} /> :
-    <p className="ola_modal-intro">{intro}</p>
-}
-
-const ModalHeader = ({ title, htmlTitle, intro, htmlIntro, children, ...props }) => {
+const ModalHeader = ({ title, intro, children, extraClass, ...props }) => {
   return (
-    <header className={cx('ola_modal-header', children && 'has-extra')} {...props}>
-      <ModalTitle title={title} htmlTitle={htmlTitle} />
-      { intro && <ModalIntro intro={intro} htmlIntro={htmlIntro} /> }
+    <header className={cx('ola_modal-header', children && 'has-extra', extraClass)} {...props}>
+      <h2 className="ola_modal-title">{title}</h2>
+      { intro && <p className="ola_modal-intro">{intro}</p> }
       { children && <div className="ola_modal-extra">{ children }</div> }
     </header>
   )
 }
 
 ModalHeader.defaultProps = {
-  intro: null,
-  htmlTitle: false,
-  htmlIntro: false,
-  children: undefined
+  intro: null
 }
 
 ModalHeader.propTypes = {
+  /** Extra className */
+  extraClass: PT.string,
   /** Title of header */
-  title: PT.string.isRequired,
-  /** Title support HTML tags */
-  htmlTitle: PT.bool,
-  /** Intro support HTML tags */
-  htmlIntro: PT.bool,
+  title: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ]).isRequired,
   /** Intro text of header */
-  intro: PT.string,
+  intro: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ]),
   /** Childen nodes */
   children: PT.oneOfType([
+    PT.string,
     PT.arrayOf(PT.node),
     PT.node
   ])

--- a/src/Modal/Header.js
+++ b/src/Modal/Header.js
@@ -13,7 +13,8 @@ const ModalHeader = ({ title, intro, children, extraClass, ...props }) => {
 }
 
 ModalHeader.defaultProps = {
-  intro: null
+  intro: null,
+  children: null
 }
 
 ModalHeader.propTypes = {

--- a/src/Modal/__snapshots__/test.js.snap
+++ b/src/Modal/__snapshots__/test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Default Modal 1`] = `
+<section
+  className="ola_modal"
+>
+  <button
+    className="ola_modal-close ola_buttonIcon"
+    onClick={[Function]}
+  >
+    <svg
+      className="ola_icon is-medium"
+      fillRule="evenodd"
+      height="28"
+      viewBox="0 0 28 28"
+      width="28"
+    >
+      <path
+        d="M22.92 4c.296 0 .55.105.762.314.212.21.318.462.318.758s-.106.55-.318.762l-8.17 8.174 8.17 8.166c.212.212.318.464.318.754 0 .296-.106.549-.318.758-.212.21-.466.314-.762.314s-.547-.103-.753-.31l-8.171-8.166-8.163 8.166c-.206.207-.46.31-.761.31a1.04 1.04 0 0 1-.758-.31A1.02 1.02 0 0 1 4 22.936c0-.301.103-.555.31-.762l8.17-8.166-8.17-8.174A1.026 1.026 0 0 1 4 5.08c0-.296.105-.55.314-.762.21-.212.462-.318.758-.318.295 0 .55.106.761.318l8.163 8.174 8.17-8.174A1.03 1.03 0 0 1 22.92 4z"
+      />
+    </svg>
+  </button>
+  <header
+    className="ola_modal-header has-extra"
+  >
+    <h2
+      className="ola_modal-title"
+    >
+      Modal Header
+    </h2>
+    <p
+      className="ola_modal-intro"
+    >
+      <strong>
+        Lorem ipsum
+      </strong>
+       for testing intro
+    </p>
+    <div
+      className="ola_modal-extra"
+    >
+      This is the extra content
+    </div>
+  </header>
+  <div
+    className="ola_modal-content"
+  >
+    <p>
+      Modal content
+    </p>
+  </div>
+  <div
+    className="ola_modal-footer"
+  >
+    This is the footer
+  </div>
+</section>
+`;

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -21,6 +21,7 @@ Modal.propTypes = {
   extraClass: PT.string,
   /** Childen nodes */
   children: PT.oneOfType([
+    PT.string,
     PT.arrayOf(PT.node),
     PT.node
   ]).isRequired

--- a/src/Modal/stories.js
+++ b/src/Modal/stories.js
@@ -14,7 +14,10 @@ storiesOf('Modal')
   .add('Default', () => (
     <div className="ola_modal-overlay">
       <Modal onClose={action('onClick event')}>
-        <ModalHeader title="Modal Header" intro="Lorem ipsum for testing intro">
+        <ModalHeader
+          title="Modal Header"
+          intro={<><strong>Lorem ipsum</strong> for testing intro</>}
+        >
           <ProgressBar value="20" max="100" />
         </ModalHeader>
         <ModalContent>

--- a/src/Modal/test.js
+++ b/src/Modal/test.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import Modal from './'
+import ModalHeader from './Header'
+import ModalContent from './Content'
+import ModalFooter from './Footer'
+import renderer from 'react-test-renderer'
+
+
+it('Default Modal', () => {
+  const tree = renderer
+    .create(
+      <Modal onClose={() => alert('onClick event')}>
+        <ModalHeader
+          title="Modal Header"
+          intro={<><strong>Lorem ipsum</strong> for testing intro</>}
+        >
+          This is the extra content
+        </ModalHeader>
+        <ModalContent>
+          <p>Modal content</p>
+        </ModalContent>
+        <ModalFooter>
+          This is the footer
+        </ModalFooter>
+      </Modal>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})

--- a/src/Panel/Content.js
+++ b/src/Panel/Content.js
@@ -2,11 +2,11 @@ import React from 'react'
 import {default as PT} from 'prop-types'
 import cx from 'classnames'
 
-const PanelContent = ({ children, title, htmlTitle, variant, extraClass, ...props }) => {
+const PanelContent = ({ children, title, variant, extraClass, ...props }) => {
   // const styles = variant ? cx('panel-content', `is-${variant}`, extraClass) : cx('panel-content', extraClass)
   return (
     <div className={cx('ola_panel-content', variant && `is-${variant}`, extraClass)} {...props}>
-      { title && ( htmlTitle ? <h2 className="ola_panel-subtitle" dangerouslySetInnerHTML={{__html: title}} /> : <h2 className="ola_panel-subtitle">{title}</h2>) }
+      { title && <h2 className="ola_panel-subtitle">{title}</h2> }
       <div>
         {children}
       </div>
@@ -17,21 +17,23 @@ const PanelContent = ({ children, title, htmlTitle, variant, extraClass, ...prop
 PanelContent.defaultProps = {
   title: null,
   extraClass: null,
-  variant: null,
-  htmlTitle: false
+  variant: null
 }
 
 PanelContent.propTypes = {
   /** Content Title */
-  title: PT.string,
-  /** Title support HTML tags */
-  htmlTitle: PT.bool,
+  title: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ]),
   /** PanelContent variants */
   variant: PT.oneOf(['fullwidth', 'highlight']),
   /** Extra className */
   extraClass: PT.string,
   /** Childen nodes */
   children: PT.oneOfType([
+    PT.string,
     PT.arrayOf(PT.node),
     PT.node
   ]).isRequired

--- a/src/Panel/Header.js
+++ b/src/Panel/Header.js
@@ -2,23 +2,11 @@ import React from 'react'
 import {default as PT} from 'prop-types'
 import cx from 'classnames'
 
-const PanelTitle = ({ title, htmlTitle=false }) => {
-  return htmlTitle ?
-    <h1 className="ola_panel-title" dangerouslySetInnerHTML={{__html: title}} /> :
-    <h1 className="ola_panel-title">{title}</h1>
-}
-
-const PanelIntro = ({ intro, htmlIntro=false }) => {
-  return htmlIntro ?
-    <p className="ola_panel-intro" dangerouslySetInnerHTML={{__html: intro}} /> :
-    <p className="ola_panel-intro">{intro}</p>
-}
-
-const PanelHeader = ({ title, htmlTitle, intro, htmlIntro, children }) => {
+const PanelHeader = ({ title, intro, extraClass, children, ...props }) => {
   return (
-    <header className={cx('ola_panel-header', children && 'has-extra')}>
-      <PanelTitle title={title} htmlTitle={htmlTitle} />
-      { intro && <PanelIntro intro={intro} htmlIntro={htmlIntro} /> }
+    <header className={cx('ola_panel-header', children && 'has-extra', extraClass)} {...props}>
+      <h1 className="ola_panel-title">{title}</h1>
+      { intro && <p className="ola_panel-intro">{intro}</p> }
       { children && <div className="ola_panel-extra">{ children }</div> }
     </header>
   )
@@ -26,22 +14,27 @@ const PanelHeader = ({ title, htmlTitle, intro, htmlIntro, children }) => {
 
 PanelHeader.defaultProps = {
   intro: null,
-  htmlTitle: false,
-  htmlIntro: false,
-  children: undefined
+  children: null
 }
 
 PanelHeader.propTypes = {
+  /** Extra className */
+  extraClass: PT.string,
   /** Title of header */
-  title: PT.string.isRequired,
-  /** Title support HTML tags */
-  htmlTitle: PT.bool,
-  /** Intro support HTML tags */
-  htmlIntro: PT.bool,
+  title: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ]).isRequired,
   /** Intro text of header */
-  intro: PT.string,
+  intro: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ]),
   /** Childen nodes */
   children: PT.oneOfType([
+    PT.string,
     PT.arrayOf(PT.node),
     PT.node
   ])

--- a/src/Panel/stories.js
+++ b/src/Panel/stories.js
@@ -49,13 +49,12 @@ storiesOf('Panel')
   .add('Titles with HTML', () => (
     <Panel>
       <PanelHeader
-        title={'Title with <span>Span</span>'}
-        htmlTitle={true}
-        intro={'Lorem ipsum for testing intro with <span>span</span>'}
-        htmlIntro={true}>
+        title={<>Title with <strong>Strong</strong></>}
+        intro={<>Lorem ipsum for testing intro with <em>cursive</em></>}
+      >
         Optional extra content
       </PanelHeader>
-      <PanelContent htmlTitle={true} extraClass="extraclass" title="Conten Titles with <span>span</span>">
+      <PanelContent extraClass="extraclass" title={<>Conten Titles with <a href="#">a link</a></>}>
         <p>Panel content</p>
       </PanelContent>
       <PanelFooter>

--- a/src/ProgressBar/__snapshots__/test.js.snap
+++ b/src/ProgressBar/__snapshots__/test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Default ProgressBar 1`] = `
+<div
+  className="ola_progressBar is-description-top"
+>
+  <progress
+    as="progress"
+    value="100"
+  />
+</div>
+`;
+
+exports[`ProgressBar with description 1`] = `
+<div
+  className="ola_progressBar is-description-top"
+>
+  <p
+    className="ola_progressBar-description"
+  >
+    This is a 
+    <strong>
+      description
+    </strong>
+  </p>
+  <progress
+    as="progress"
+    value="100"
+  />
+</div>
+`;

--- a/src/ProgressBar/index.js
+++ b/src/ProgressBar/index.js
@@ -3,17 +3,11 @@ import {default as PT} from 'prop-types'
 import cx from 'classnames'
 import { getElementType } from '../utils'
 
-const ProgressBarDescription = ({ description, htmlDescription=false }) => {
-  return htmlDescription ?
-    <p className="ola_progressBar-description" dangerouslySetInnerHTML={{__html: description}} /> :
-    <p className="ola_progressBar-description">{description}</p>
-}
-
-const ProgressBar = ({ extraClass, description, descriptionPosition, htmlDescription, ...props }) => {
+const ProgressBar = ({ extraClass, children, descriptionPosition, ...props }) => {
   const ElementType = getElementType(ProgressBar, {...props})
   return (
     <div className={cx('ola_progressBar', `is-description-${descriptionPosition}`, extraClass)}>
-      { description && <ProgressBarDescription description={description} htmlDescription={htmlDescription} /> }
+      { children && <p className="ola_progressBar-description">{children}</p> }
       <ElementType {...props} />
     </div>
   )
@@ -22,21 +16,22 @@ const ProgressBar = ({ extraClass, description, descriptionPosition, htmlDescrip
 ProgressBar.defaultProps = {
   as: 'progress',
   extraClass: null,
-  description: null,
-  descriptionPosition: 'top',
-  htmlDescription: false
+  children: null,
+  descriptionPosition: 'top'
 }
 
 ProgressBar.propTypes = {
   as: PT.oneOf(['progress', 'meter']),
   /** Extra className */
   extraClass: PT.string,
-  /** Description */
-  description: PT.string,
   /** Description Position */
   descriptionPosition: PT.oneOf(['top', 'right']),
-  /** Description support HTML tags */
-  htmlDescription: PT.bool
+  /** Childen nodes */
+  children: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ])
 }
 
 export default ProgressBar

--- a/src/ProgressBar/stories.js
+++ b/src/ProgressBar/stories.js
@@ -7,14 +7,22 @@ storiesOf('ProgressBar')
   .add('Progress element', () => (
     <div>
       <figure><ProgressBar value="20" max="100" /></figure>
-      <figure><ProgressBar value="50" max="100" description="Loading..." /></figure>
-      <figure><ProgressBar value="80" max="100" htmlDescription description="<strong>20%</strong> completed" descriptionPosition="right" /></figure>
+      <figure><ProgressBar value="50" max="100">Loading...</ProgressBar></figure>
+      <figure>
+        <ProgressBar value="80" max="100" descriptionPosition="right">
+          <strong>20%</strong> completed
+        </ProgressBar>
+      </figure>
     </div>
   ))
   .add('Meter element', () => (
     <div>
       <figure><ProgressBar as="meter" value="120" min="100" max="200" low="130" /></figure>
-      <figure><ProgressBar as="meter" value="150" min="100" max="200" description="150 / 200" /></figure>
-      <figure><ProgressBar as="meter" value="180" min="100" max="200" htmlDescription description="<strong>180 / 200</strong>" descriptionPosition="right" /></figure>
+      <figure><ProgressBar as="meter" value="150" min="100" max="200">150 / 200</ProgressBar></figure>
+      <figure>
+        <ProgressBar as="meter" value="180" min="100" max="200" descriptionPosition="right">
+          <strong>180 / 200</strong>
+        </ProgressBar>
+      </figure>
     </div>
   ))

--- a/src/ProgressBar/test.js
+++ b/src/ProgressBar/test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import ProgressBar from './'
+import renderer from 'react-test-renderer'
+
+
+it('Default ProgressBar', () => {
+  const tree = renderer
+    .create(
+      <ProgressBar value="100" />
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})
+
+it('ProgressBar with description', () => {
+  const tree = renderer
+    .create(
+      <ProgressBar value="100">This is a <strong>description</strong></ProgressBar>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})

--- a/src/Switch/__snapshots__/test.js.snap
+++ b/src/Switch/__snapshots__/test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Default Switch 1`] = `
+<label
+  className="ola_switch"
+>
+  <input
+    className="ola_switch-input"
+    label={null}
+    type="checkbox"
+  />
+  <div
+    className="ola_switch-label"
+  >
+    <div
+      className="ola_switch-label-content"
+    >
+      Label text
+    </div>
+  </div>
+</label>
+`;
+
+exports[`Extra class Switch 1`] = `
+<label
+  className="ola_switch foo"
+>
+  <input
+    className="ola_switch-input"
+    label={null}
+    type="checkbox"
+  />
+  <div
+    className="ola_switch-label"
+  >
+    <div
+      className="ola_switch-label-content"
+    >
+      Label text
+    </div>
+  </div>
+</label>
+`;

--- a/src/Switch/index.js
+++ b/src/Switch/index.js
@@ -1,11 +1,14 @@
 import React from 'react'
+import cx from 'classnames'
 import {default as PT} from 'prop-types'
 
-const Switch = ({ label, htmlLabel, ...props }) => {
+const Switch = ({ children, extraClass, ...props }) => {
   return (
-    <label className="ola_switch">
+    <label className={cx('ola_switch', extraClass)}>
       <input type="checkbox" className="ola_switch-input" {...props} />
-      { label && ( htmlLabel ? <span className="ola_switch-label" dangerouslySetInnerHTML={{__html: label}} /> : <span className="ola_switch-label">{ label }</span>) }
+      <div className="ola_switch-label">
+        { children && <div className="ola_switch-label-content">{ children }</div> }
+      </div>
     </label>
   )
 }
@@ -15,12 +18,14 @@ Switch.defaultProps = {
 }
 
 Switch.propTypes = {
-  /** Label Switch */
-  label: PT.string,
-  /** Label support HTML tags */
-  htmlLabel: PT.bool,
-  /** Redux Forms input Switch */
-  input: PT.object
+  /** Extra className */
+  extraClass: PT.string,
+  /** Childen nodes */
+  children: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ])
 }
 
 export default Switch

--- a/src/Switch/stories.js
+++ b/src/Switch/stories.js
@@ -5,8 +5,14 @@ import Switch from './'
 
 storiesOf('Switch')
   .add('Default', () => (
-    <figure><Switch label="Switch" /></figure>
+    <figure>
+      <Switch>Switch</Switch>
+    </figure>
   ))
   .add('With link', () => (
-    <figure><Switch label="Switch&nbsp;<a href='#'>with link</a>" htmlLabel /></figure>
+    <figure>
+      <Switch>
+        Switch <a href='#'>with link</a>
+      </Switch>
+    </figure>
   ))

--- a/src/Switch/test.js
+++ b/src/Switch/test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import Switch from './'
+import renderer from 'react-test-renderer'
+
+
+it('Default Switch', () => {
+  const tree = renderer
+    .create(
+      <Switch>Label text</Switch>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})
+
+it('Extra class Switch', () => {
+  const tree = renderer
+    .create(
+      <Switch extraClass="foo">Label text</Switch>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})

--- a/src/Task/index.js
+++ b/src/Task/index.js
@@ -12,21 +12,18 @@ const TaskIcon = ({ variant }) => {
   }
 }
 
-const TaskTitle = ({ title, htmlTitle, extra }) => 
+const TaskTitle = ({ title, extra }) => 
   <>
-    {htmlTitle ?
-      <span className="ola_task-title" dangerouslySetInnerHTML={{__html: title}} /> :
-      <span className="ola_task-title">{title}</span>
-    }
+    <span className="ola_task-title">{title}</span>
     {extra && <div className="ola_task-extra">{extra}</div>}
   </>
 
-const TaskSumary = ({ title, htmlTitle, variant, extra }) => {
+const TaskSumary = ({ title, variant, extra }) => {
   return (
     <summary className="ola_task-summary">
       <div className={'ola_task-header'}>
         <TaskIcon variant={variant} />
-        <TaskTitle title={title} htmlTitle={htmlTitle} extra={extra} />
+        <TaskTitle title={title} extra={extra} />
         <span className="ola_task-icon ola_buttonIcon">
           <Icon name="close" extraClass="ola_task-icon-close" />
         </span>
@@ -35,12 +32,12 @@ const TaskSumary = ({ title, htmlTitle, variant, extra }) => {
   )
 }
 
-const Task = ({ title, htmlTitle, variant, children, extra, ...props }) => {
+const Task = ({ title, variant, children, extra, ...props }) => {
   const hasChildren = React.Children.count(children) > 0
   return hasChildren ?
     (
       <details className={cx('ola_task', variant && `is-${variant}`)} {...props}>
-        <TaskSumary title={title} htmlTitle={htmlTitle} variant={variant} extra={extra} />
+        <TaskSumary title={title} variant={variant} extra={extra} />
         <div className='ola_task-content'>
           { children }
         </div>
@@ -50,7 +47,7 @@ const Task = ({ title, htmlTitle, variant, children, extra, ...props }) => {
       <div className={cx('ola_task', variant && `is-${variant}`)}>
         <div className="ola_task-header">
           <TaskIcon variant={variant} />
-          <TaskTitle title={title} htmlTitle={htmlTitle} extra={extra} />
+          <TaskTitle title={title} extra={extra} />
         </div>
       </div>
     )
@@ -59,16 +56,17 @@ const Task = ({ title, htmlTitle, variant, children, extra, ...props }) => {
 
 Task.defaultProps = {
   variant: 'error',
-  htmlTitle: false
 }
 
 Task.propTypes = {
   /** Task variants */
   variant: PT.oneOf(['success', 'error', 'suggested', 'warning']),
   /** Title of header */
-  title: PT.string.isRequired,
-  /** Title support HTML tags */
-  htmlTitle: PT.bool,
+  title: PT.oneOfType([
+    PT.string,
+    PT.arrayOf(PT.node),
+    PT.node
+  ]).isRequired,
   /** Childen nodes */
   children: PT.oneOfType([
     PT.string,

--- a/src/Task/stories.js
+++ b/src/Task/stories.js
@@ -50,7 +50,7 @@ storiesOf('Task')
             </TaskFooter>
           </Task>
 
-          <Task htmlTitle title="Task html title <strong>demo 3</strong>" extra={<Button onClick={e => {e.preventDefault();alert('click')}}>Fix now</Button>}>
+          <Task title={<>Task html title <strong>demo 3</strong></>} extra={<Button onClick={e => {e.preventDefault();alert('click')}}>Fix now</Button>}>
             <TaskBody>
               Test content for card resolve
             </TaskBody>

--- a/src/stories.js
+++ b/src/stories.js
@@ -1,2 +1,2 @@
 // STYLES
-import '../dist/index.css'
+import './index.css'


### PR DESCRIPTION
This fixes #28 

Affects to the following components:

- Switch
- Metric
- Modal
- Panel
- ProgressBar
- Task

In some cases, the property is converted to `children`:

```jsx
<Switch>
    This is the <strong>label</strong>
<Switch>

<ProgressBar>
    <strong>20%</strong> completed
</ProgressBar>
```

In other cases, the property is the same but accepting more value types (node and array of nodes):

```jsx
<Metric
    title="Do you have a blog?"
    footer={<>We found a Blog at <a href="#">http:blog.example.com</a></>}
    value="Yes"
    variant="positive"
/>
```
