### PR TITLE
feat: modal improvements added #74

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "react-test-renderer": "16.8.6"
+  },
+  "dependencies": {
+    "dialog-polyfill": "^0.5.0"
   }
 }

--- a/src/ButtonIcon/index.js
+++ b/src/ButtonIcon/index.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import {default as PT} from 'prop-types'
 import { getElementType } from '../utils'
+import cx from 'classnames'
 
-const ButtonIcon = ({ as, children, ...props }) => {
+const ButtonIcon = ({ as, extraClass, children, ...props }) => {
   const ElementType = getElementType(ButtonIcon, { as: as, ...props })
-  return (<ElementType {...props} className='ola_buttonIcon'>{children}</ElementType>)
+  return (<ElementType {...props} className={cx('ola_buttonIcon', extraClass)}>{children}</ElementType>)
 }
 
 ButtonIcon.defaultProps = {
@@ -14,6 +15,8 @@ ButtonIcon.defaultProps = {
 ButtonIcon.propTypes = {
   /** Render ButtonIcon with any html tag */
   as: PT.string,
+  /** Extra className */
+  extraClass: PT.string,
   /** Childen nodes */
   children: PT.oneOfType([
     PT.string,

--- a/src/Modal/__snapshots__/test.js.snap
+++ b/src/Modal/__snapshots__/test.js.snap
@@ -1,25 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Default Modal 1`] = `
-<section
+<dialog
   className="ola_modal"
+  onClick={[Function]}
 >
-  <button
-    className="ola_modal-close ola_buttonIcon"
-    onClick={[Function]}
-  >
-    <svg
-      className="ola_icon is-medium"
-      fillRule="evenodd"
-      height="28"
-      viewBox="0 0 28 28"
-      width="28"
-    >
-      <path
-        d="M22.92 4c.296 0 .55.105.762.314.212.21.318.462.318.758s-.106.55-.318.762l-8.17 8.174 8.17 8.166c.212.212.318.464.318.754 0 .296-.106.549-.318.758-.212.21-.466.314-.762.314s-.547-.103-.753-.31l-8.171-8.166-8.163 8.166c-.206.207-.46.31-.761.31a1.04 1.04 0 0 1-.758-.31A1.02 1.02 0 0 1 4 22.936c0-.301.103-.555.31-.762l8.17-8.166-8.17-8.174A1.026 1.026 0 0 1 4 5.08c0-.296.105-.55.314-.762.21-.212.462-.318.758-.318.295 0 .55.106.761.318l8.163 8.174 8.17-8.174A1.03 1.03 0 0 1 22.92 4z"
-      />
-    </svg>
-  </button>
   <header
     className="ola_modal-header has-extra"
   >
@@ -54,5 +39,22 @@ exports[`Default Modal 1`] = `
   >
     This is the footer
   </div>
-</section>
+  <button
+    className="ola_buttonIcon ola_modal-close"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      className="ola_icon is-medium"
+      fillRule="evenodd"
+      height="28"
+      viewBox="0 0 28 28"
+      width="28"
+    >
+      <path
+        d="M22.92 4c.296 0 .55.105.762.314.212.21.318.462.318.758s-.106.55-.318.762l-8.17 8.174 8.17 8.166c.212.212.318.464.318.754 0 .296-.106.549-.318.758-.212.21-.466.314-.762.314s-.547-.103-.753-.31l-8.171-8.166-8.163 8.166c-.206.207-.46.31-.761.31a1.04 1.04 0 0 1-.758-.31A1.02 1.02 0 0 1 4 22.936c0-.301.103-.555.31-.762l8.17-8.166-8.17-8.174A1.026 1.026 0 0 1 4 5.08c0-.296.105-.55.314-.762.21-.212.462-.318.758-.318.295 0 .55.106.761.318l8.163 8.174 8.17-8.174A1.03 1.03 0 0 1 22.92 4z"
+      />
+    </svg>
+  </button>
+</dialog>
 `;

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -16,7 +16,12 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
     if(!isInDialog) { onClose() }
   }
 
-  useEffect(() => dialogPolyfill.registerDialog(modal.current), [])
+  useEffect(() => {
+    dialogPolyfill.registerDialog(modal.current)
+    modal.current.addEventListener('close', onClose)
+    return () => modal.current.removeEventListener('close')
+  }, [])
+
   useEffect(() => {
     if(modal.current) {
       if(open && (modal.current.open === false)) { modal.current.showModal(); onOpen() }

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -29,14 +29,14 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
   useEventListener(modal.current, 'close', closeModal)
 
   return (
-    <div onClick={closeModal}>
+    // <div onClick={closeModal}>
       <dialog className={cx('ola_modal')} {...props} ref={modal}>
         {children}
         <ButtonIcon type="button" onClick={closeModal} extraClass={'ola_modal-close'}>
           <Icon name="close" />
         </ButtonIcon>
       </dialog>
-    </div>
+    // </div>
   )
 
 }

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -16,12 +16,12 @@ const Modal = ({ extraClass, children, open, onClose, ...props }) => {
   if (open){
     return (
       <div className="ola_modal-overlay" onClick={onClose}>
-        <dialog onClick={e => e.stopPropagation()} className={cx('ola_modal', extraClass)} open={open} {...props}>
+        <section onClick={e => e.stopPropagation()} className={cx('ola_modal', extraClass)} {...props}>
           <ButtonIcon extraClass="ola_modal-close ola_buttonIcon" onClick={onClose}>
             <Icon name="close" />
           </ButtonIcon>
           {children}
-        </dialog>
+        </section>
       </div>
     )
   }

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import {default as PT} from 'prop-types'
 import cx from 'classnames'
 import Icon from '../Icon'
+import ButtonIcon from '../ButtonIcon'
 
 const Modal = ({ extraClass, children, open, onClose, ...props }) => {
     
@@ -16,9 +17,9 @@ const Modal = ({ extraClass, children, open, onClose, ...props }) => {
     return (
       <div className="ola_modal-overlay" onClick={onClose}>
         <dialog onClick={e => e.stopPropagation()} className={cx('ola_modal', extraClass)} open={open} {...props}>
-          <button className="ola_modal-close ola_buttonIcon" onClick={onClose}>
+          <ButtonIcon extraClass="ola_modal-close ola_buttonIcon" onClick={onClose}>
             <Icon name="close" />
-          </button>
+          </ButtonIcon>
           {children}
         </dialog>
       </div>

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -1,20 +1,36 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import {default as PT} from 'prop-types'
 import cx from 'classnames'
 import Icon from '../Icon'
 
-const Modal = ({ extraClass, children, onClose, ...props }) => {
+const Overlay = ({ children, open, ...props }) => open ?
+  <div className="ola_modal-overlay" {...props}>
+    {children}
+  </div> : null
+
+const Modal = ({ extraClass, children, closeWhenClickOut = true, closeWhenPressEsc = true, onClose, ...props }) => {
+    
+  useEffect(() => closeWhenPressEsc && document.body.addEventListener('keydown', e => e.keyCode === 27 && onClose()), [])
+
   return (
-    <section className={cx('ola_modal', extraClass)} {...props}>
-      <button className="ola_modal-close ola_buttonIcon" onClick={() => onClose()}>
-        <Icon name="close" />
-      </button>
-      {children}
-    </section>
+    <Overlay onClick={closeWhenClickOut && onClose} {...props}>
+      <dialog onClick={e => e.stopPropagation()} className={cx('ola_modal', extraClass)} {...props}>
+        <button className="ola_modal-close ola_buttonIcon" onClick={onClose}>
+          <Icon name="close" />
+        </button>
+        {children}
+      </dialog>
+    </Overlay>
   )
 }
 
 Modal.propTypes = {
+  /** Open or close Modal */
+  open: PT.bool,
+  /** Close Modal when click out. Default is true */
+  closeWhenClickOut: PT.bool,
+  /** Close Modal when press ESC. Default is true */
+  closeWhenPressEsc: PT.bool,
   /** On Close function */
   onClose: PT.func,
   /** Extra className */

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react'
 import {default as PT} from 'prop-types'
-import cx from 'classnames'
 import dialogPolyfill from 'dialog-polyfill'
 import useEventListener from '../hooks/useEventListener'
 import Icon from '../Icon'
@@ -9,10 +8,12 @@ import ButtonIcon from '../ButtonIcon'
 const Modal = ({ open, onClose, onOpen, children, ...props }) => {
 
   const modal = useRef(null)
+  const mounted = useRef(null)
 
   const closeModal = () => {
-    modal.current.close()
-    onClose()
+    if (modal.current.open){
+      modal.current.close()
+    }
   }
 
   const openModal = () => {
@@ -25,21 +26,26 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
     const rect = modal.current.getBoundingClientRect()
     const isInDialog = (rect.top <= event.clientY && event.clientY <= rect.top + rect.height
       && rect.left <= event.clientX && event.clientX <= rect.left + rect.width)
-    if(!isInDialog) { closeModal() }
+    if(!isInDialog) { onClose() }
   }
 
+  useEffect(() => dialogPolyfill.registerDialog(modal.current), [])
+
   useEffect(() => {
-    if(modal.current) dialogPolyfill.registerDialog(modal.current)
-    if (open && modal.current && (modal.current.open === false) ) { openModal() }
-    if(!open && modal.current && (modal.current.open === true)) { closeModal() }
+    if (!mounted.current){
+      mounted.current = true
+    }else{
+      if (open){ openModal() } 
+      else{ closeModal() }
+    }
   })
 
   useEventListener(modal.current, 'close', onClose)
 
   return (
-    <dialog className={cx('ola_modal')} {...props} ref={modal} onClick={clickOutside}>
+    <dialog className='ola_modal' {...props} ref={modal} onClick={clickOutside}>
       {children}
-      <ButtonIcon type="button" onClick={closeModal} extraClass={'ola_modal-close'}>
+      <ButtonIcon type="button" onClick={onClose} extraClass={'ola_modal-close'}>
         <Icon name="close" />
       </ButtonIcon>
     </dialog>

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -20,6 +20,14 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
     onOpen()
   }
 
+  // We can't use useOutsideEvent hook. Dialog height and width is 100%
+  const clickOutside = event => {
+    const rect = modal.current.getBoundingClientRect()
+    const isInDialog = (rect.top <= event.clientY && event.clientY <= rect.top + rect.height
+      && rect.left <= event.clientX && event.clientX <= rect.left + rect.width)
+    if(!isInDialog) { closeModal() }
+  }
+
   useEffect(() => {
     if(modal.current) dialogPolyfill.registerDialog(modal.current)
     if (open && modal.current && (modal.current.open === false) ) { openModal() }
@@ -29,14 +37,12 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
   useEventListener(modal.current, 'close', closeModal)
 
   return (
-    // <div onClick={closeModal}>
-      <dialog className={cx('ola_modal')} {...props} ref={modal}>
-        {children}
-        <ButtonIcon type="button" onClick={closeModal} extraClass={'ola_modal-close'}>
-          <Icon name="close" />
-        </ButtonIcon>
-      </dialog>
-    // </div>
+    <dialog className={cx('ola_modal')} {...props} ref={modal} onClick={clickOutside}>
+      {children}
+      <ButtonIcon type="button" onClick={closeModal} extraClass={'ola_modal-close'}>
+        <Icon name="close" />
+      </ButtonIcon>
+    </dialog>
   )
 
 }

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -3,34 +3,33 @@ import {default as PT} from 'prop-types'
 import cx from 'classnames'
 import Icon from '../Icon'
 
-const Overlay = ({ children, open, ...props }) => open ?
-  <div className="ola_modal-overlay" {...props}>
-    {children}
-  </div> : null
-
-const Modal = ({ extraClass, children, closeWhenClickOut = true, closeWhenPressEsc = true, onClose, ...props }) => {
+const Modal = ({ extraClass, children, open, onClose, ...props }) => {
     
-  useEffect(() => closeWhenPressEsc && document.body.addEventListener('keydown', e => e.keyCode === 27 && onClose()), [])
+  useEffect(() => {
+    if (open){
+      document.body.addEventListener('keydown', e => e.keyCode === 27 && onClose())
+      return () => document.body.removeEventListener('keydown')
+    }
+  },[])
 
-  return (
-    <Overlay onClick={closeWhenClickOut && onClose} {...props}>
-      <dialog onClick={e => e.stopPropagation()} className={cx('ola_modal', extraClass)} {...props}>
-        <button className="ola_modal-close ola_buttonIcon" onClick={onClose}>
-          <Icon name="close" />
-        </button>
-        {children}
-      </dialog>
-    </Overlay>
-  )
+  if (open){
+    return (
+      <div className="ola_modal-overlay" onClick={onClose}>
+        <dialog onClick={e => e.stopPropagation()} className={cx('ola_modal', extraClass)} open={open} {...props}>
+          <button className="ola_modal-close ola_buttonIcon" onClick={onClose}>
+            <Icon name="close" />
+          </button>
+          {children}
+        </dialog>
+      </div>
+    )
+  }
+  return null
 }
 
 Modal.propTypes = {
   /** Open or close Modal */
   open: PT.bool,
-  /** Close Modal when click out. Default is true */
-  closeWhenClickOut: PT.bool,
-  /** Close Modal when press ESC. Default is true */
-  closeWhenPressEsc: PT.bool,
   /** On Close function */
   onClose: PT.func,
   /** Extra className */

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import {default as PT} from 'prop-types'
 import dialogPolyfill from 'dialog-polyfill'
+import useEventListener from '../hooks/useEventListener'
 import Icon from '../Icon'
 import ButtonIcon from '../ButtonIcon'
 
@@ -16,11 +17,8 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
     if(!isInDialog) { onClose() }
   }
 
-  useEffect(() => {
-    dialogPolyfill.registerDialog(modal.current)
-    modal.current.addEventListener('close', onClose)
-    return () => modal.current.removeEventListener('close')
-  }, [])
+  useEffect(() => { dialogPolyfill.registerDialog(modal.current) }, [])
+  useEventListener(modal.current, 'close', onClose)
 
   useEffect(() => {
     if(modal.current) {
@@ -31,10 +29,14 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
 
   return (
     <dialog className='ola_modal' {...props} ref={modal} onClick={clickOutside}>
-      {children}
-      <ButtonIcon type="button" onClick={onClose} extraClass={'ola_modal-close'}>
-        <Icon name="close" />
-      </ButtonIcon>
+      { open &&
+        <>
+          {children}
+          <ButtonIcon type="button" onClick={onClose} extraClass={'ola_modal-close'}>
+            <Icon name="close" />
+          </ButtonIcon>
+        </>
+      }
     </dialog>
   )
 

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -34,7 +34,7 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
     if(!open && modal.current && (modal.current.open === true)) { closeModal() }
   })
 
-  useEventListener(modal.current, 'close', closeModal)
+  useEventListener(modal.current, 'close', onClose)
 
   return (
     <dialog className={cx('ola_modal')} {...props} ref={modal} onClick={clickOutside}>

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -1,25 +1,12 @@
 import React, { useEffect, useRef } from 'react'
 import {default as PT} from 'prop-types'
 import dialogPolyfill from 'dialog-polyfill'
-import useEventListener from '../hooks/useEventListener'
 import Icon from '../Icon'
 import ButtonIcon from '../ButtonIcon'
 
 const Modal = ({ open, onClose, onOpen, children, ...props }) => {
 
   const modal = useRef(null)
-  const mounted = useRef(null)
-
-  const closeModal = () => {
-    if (modal.current.open){
-      modal.current.close()
-    }
-  }
-
-  const openModal = () => {
-    modal.current.showModal()
-    onOpen()
-  }
 
   // We can't use useOutsideEvent hook. Dialog height and width is 100%
   const clickOutside = event => {
@@ -30,17 +17,12 @@ const Modal = ({ open, onClose, onOpen, children, ...props }) => {
   }
 
   useEffect(() => dialogPolyfill.registerDialog(modal.current), [])
-
   useEffect(() => {
-    if (!mounted.current){
-      mounted.current = true
-    }else{
-      if (open){ openModal() } 
-      else{ closeModal() }
+    if(modal.current) {
+      if(open && (modal.current.open === false)) { modal.current.showModal(); onOpen() }
+      if(!open && (modal.current.open === true)) { modal.current.close() }
     }
   })
-
-  useEventListener(modal.current, 'close', onClose)
 
   return (
     <dialog className='ola_modal' {...props} ref={modal} onClick={clickOutside}>

--- a/src/Modal/stories.js
+++ b/src/Modal/stories.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
-import { action, actions } from '@storybook/addon-actions'
+import { action } from '@storybook/addon-actions'
 
 import Modal from './'
 import ModalHeader from './Header'
@@ -16,9 +16,7 @@ import ProgressBar from '../ProgressBar'
 storiesOf('Modal')
   .add('Default', () => {
 
-    const [isOpen, setIsOpen] = useState(false)
-
-    const eventsFromObject = actions({ onClose: 'onClose event' })
+    const [isOpen, setIsOpen] = useState()
 
     return (
       <>
@@ -59,8 +57,7 @@ storiesOf('Modal')
         <Modal
           open={isOpen}
           onOpen={ action('onOpen event') }
-          onClose={() => { setIsOpen(false) }}
-          { ...eventsFromObject }
+          onClose={ () => { setIsOpen(false) }}
         >
           <ModalHeader
             title="Modal Header"

--- a/src/Modal/stories.js
+++ b/src/Modal/stories.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
+import { action, actions } from '@storybook/addon-actions'
 
 import Modal from './'
 import ModalHeader from './Header'
@@ -16,6 +17,9 @@ storiesOf('Modal')
   .add('Default', () => {
 
     const [isOpen, setIsOpen] = useState(false)
+
+    const eventsFromObject = actions({ onClose: 'onClose event' })
+
     return (
       <>
         <Panel>
@@ -52,7 +56,12 @@ storiesOf('Modal')
             <h1>Panel content</h1>
           </PanelContent>
         </Panel>
-        <Modal open={isOpen} onClose={() => setIsOpen(false)}>
+        <Modal
+          open={isOpen}
+          onOpen={ action('onOpen event') }
+          onClose={() => { setIsOpen(false) }}
+          { ...eventsFromObject }
+        >
           <ModalHeader
             title="Modal Header"
             intro={<><strong>Lorem ipsum</strong> for testing intro</>}>

--- a/src/Modal/stories.js
+++ b/src/Modal/stories.js
@@ -21,35 +21,35 @@ storiesOf('Modal')
         <Panel>
           <PanelContent title="Test dialog">
             <Button onClick={() => setIsOpen(true)}>Open dialog</Button>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
-            <h1>Modal content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
           </PanelContent>
         </Panel>
         <Modal open={isOpen} onClose={() => setIsOpen(false)}>
@@ -59,7 +59,35 @@ storiesOf('Modal')
             <ProgressBar value="20" max="100" />
           </ModalHeader>
           <ModalContent>
-            <p>Modal content</p>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
+            <h1>Panel content</h1>
           </ModalContent>
           <ModalFooter>
             <ButtonGroup variant='reversed'>

--- a/src/Modal/stories.js
+++ b/src/Modal/stories.js
@@ -1,6 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
-import { action } from '@storybook/addon-actions'
 
 import Modal from './'
 import ModalHeader from './Header'
@@ -8,24 +7,68 @@ import ModalContent from './Content'
 import ModalFooter from './Footer'
 import Button from '../Button'
 import ButtonGroup from '../ButtonGroup'
+
+import Panel from '../Panel'
+import PanelContent from '../Panel/Content'
 import ProgressBar from '../ProgressBar'
 
 storiesOf('Modal')
-  .add('Default', () => (
-    <Modal onClose={action('onClick event')} open>
-      <ModalHeader
-        title="Modal Header"
-        intro={<><strong>Lorem ipsum</strong> for testing intro</>}>
-        <ProgressBar value="20" max="100" />
-      </ModalHeader>
-      <ModalContent>
-        <p>Modal content</p>
-      </ModalContent>
-      <ModalFooter>
-        <ButtonGroup variant='reversed'>
-          <Button variant='primary'>Primary</Button>
-          <Button variant='secondary'>Default Button</Button>
-        </ButtonGroup>
-      </ModalFooter>
-    </Modal>
-  ))
+  .add('Default', () => {
+
+    const [isOpen, setIsOpen] = useState(false)
+    return (
+      <>
+        <Panel>
+          <PanelContent title="Test dialog">
+            <Button onClick={() => setIsOpen(true)}>Open dialog</Button>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+            <h1>Modal content</h1>
+          </PanelContent>
+        </Panel>
+        <Modal open={isOpen} onClose={() => setIsOpen(false)}>
+          <ModalHeader
+            title="Modal Header"
+            intro={<><strong>Lorem ipsum</strong> for testing intro</>}>
+            <ProgressBar value="20" max="100" />
+          </ModalHeader>
+          <ModalContent>
+            <p>Modal content</p>
+          </ModalContent>
+          <ModalFooter>
+            <ButtonGroup variant='reversed'>
+              <Button variant='primary'>Primary</Button>
+              <Button variant='secondary'>Default Button</Button>
+            </ButtonGroup>
+          </ModalFooter>
+        </Modal>
+      </>
+    )
+
+  })

--- a/src/Modal/stories.js
+++ b/src/Modal/stories.js
@@ -57,7 +57,10 @@ storiesOf('Modal')
         <Modal
           open={isOpen}
           onOpen={ action('onOpen event') }
-          onClose={ () => { setIsOpen(false) }}
+          onClose={() => {
+            setIsOpen(false)
+            action('onClose event')()
+          }}
         >
           <ModalHeader
             title="Modal Header"

--- a/src/Modal/stories.js
+++ b/src/Modal/stories.js
@@ -12,23 +12,20 @@ import ProgressBar from '../ProgressBar'
 
 storiesOf('Modal')
   .add('Default', () => (
-    <div className="ola_modal-overlay">
-      <Modal onClose={action('onClick event')}>
-        <ModalHeader
-          title="Modal Header"
-          intro={<><strong>Lorem ipsum</strong> for testing intro</>}
-        >
-          <ProgressBar value="20" max="100" />
-        </ModalHeader>
-        <ModalContent>
-          <p>Modal content</p>
-        </ModalContent>
-        <ModalFooter>
-          <ButtonGroup reversed>
-            <Button variant='primary'>Primary</Button>
-            <Button variant='secondary'>Default Button</Button>
-          </ButtonGroup>
-        </ModalFooter>
-      </Modal>
-    </div>
+    <Modal onClose={action('onClick event')} open>
+      <ModalHeader
+        title="Modal Header"
+        intro={<><strong>Lorem ipsum</strong> for testing intro</>}>
+        <ProgressBar value="20" max="100" />
+      </ModalHeader>
+      <ModalContent>
+        <p>Modal content</p>
+      </ModalContent>
+      <ModalFooter>
+        <ButtonGroup variant='reversed'>
+          <Button variant='primary'>Primary</Button>
+          <Button variant='secondary'>Default Button</Button>
+        </ButtonGroup>
+      </ModalFooter>
+    </Modal>
   ))

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -63,6 +63,9 @@
     box-sizing: border-box;
     padding: var(--size-8);
     overflow: auto;
+    @media (--to-width-1) {
+        padding: var(--size-4);
+    }
 }
 
 @keyframes modal-show {

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -3,6 +3,7 @@
     border-radius: var(--radius);
     border: none;
     box-shadow: var(--shadow-3), var(--shadow-line);
+    width: 100%;
     max-width: 850px;
     margin: 8vh auto;
     animation: modal-show .5s;

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -63,6 +63,7 @@
     box-sizing: border-box;
     padding: var(--size-8);
     overflow: auto;
+    animation: overlay-show .5s;
     @media (--to-width-1) {
         padding: var(--size-4);
     }
@@ -78,5 +79,14 @@
     }
     to {
         transform: translateY(0);
+    }
+}
+
+@keyframes overlay-show {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
     }
 }

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -3,7 +3,6 @@
     border-radius: var(--radius);
     border: none;
     box-shadow: var(--shadow-3), var(--shadow-line);
-    width: 100%;
     max-width: 850px;
     margin: 8vh auto;
     animation: modal-show .5s;

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -30,9 +30,11 @@
 
 .ola_modal::backdrop {
     background: #0006;
+    animation: fadeIn .4s;
 }
 .ola_modal + .backdrop {
     background: #0006;
+    animation: fadeIn .4s;
 }
 .ola_modal + .backdrop,
 ._dialog_overlay {
@@ -107,5 +109,14 @@
     }
     to {
         transform: translateY(0);
+    }
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
     }
 }

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -4,9 +4,9 @@
     border: none;
     box-shadow: var(--shadow-3), var(--shadow-line);
     max-width: 850px;
-    max-height: 90vh;
-    width: calc(100% - 10vw);
-    margin: 5vh auto;
+    max-height: calc(100vh - 5vw);
+    width: calc(100% - 5vw);
+    margin: 2.5vw auto 0;
     animation: modal-show .5s;
     animation-fill-mode: both;
     position: fixed;
@@ -21,8 +21,10 @@
       display: flex;
     }
 
-    & > .ola_modal-header {
-        padding: var(--inner-gap);
+    @media (--from-width-1) {
+        margin: 5vh auto 0;
+        width: calc(100% - 10vw);
+        max-height: calc(100vh - 10vh);
     }
 }
 
@@ -42,8 +44,10 @@
   display: grid;
   grid-template-areas: "title" "intro";
   grid-template-columns: 1fr auto;
-  grid-column-gap: var(--size-6);
+  grid-column-gap: var(--column-gap);
+  grid-row-gap: var(--size-3);
   flex: 0 0 auto;
+  padding: var(--inner-gap) var(--inner-gap) var(--size-3);
 
   &.has-extra {
         grid-template-areas: "title" "intro" "extra";
@@ -72,17 +76,24 @@
 }
 .ola_modal-intro {
     grid-area: intro;
-    margin: var(--size-3) 0 0;
+    margin: 0;
     font: var(--font-callout);
     color: var(--gray);
 }
 .ola_modal-content {
-    padding: var(--inner-gap);
+    padding: var(--size-3) var(--inner-gap);
     min-height: 0;
     overflow-y: auto;
+
+    &:first-child {
+        padding-top: var(--inner-gap);
+    }
+    &:last-child {
+        padding-bottom: var(--inner-gap);
+    }
 }
 .ola_modal-footer {
-    padding: 0  var(--inner-gap) var(--inner-gap);
+    padding: var(--size-3)  var(--inner-gap) var(--inner-gap);
     flex: 0 0 auto;
 }
 

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -4,10 +4,17 @@
     border: none;
     box-shadow: var(--shadow-3), var(--shadow-line);
     max-width: 850px;
+    width: 100%;
     margin: 8vh auto;
     animation: modal-show .5s;
     animation-fill-mode: both;
     position: relative;
+    display: none;
+
+    &[open] {
+      display: block;
+    }
+
     & > .ola_modal-header {
         padding: var(--inner-gap) var(--inner-gap) 0;
     }
@@ -88,4 +95,22 @@
     to {
         opacity: 1;
     }
+}
+
+// polyfill
+
+dialog + .backdrop {
+  position: fixed;
+  top: 0; right: 0; bottom: 0; left: 0;
+}
+
+._dialog_overlay {
+  position: fixed;
+  top: 0; right: 0; bottom: 0; left: 0;
+}
+
+dialog.fixed {
+  position: fixed;
+  top: 50%;
+  transform: translate(0, -50%);
 }

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -4,20 +4,38 @@
     border: none;
     box-shadow: var(--shadow-3), var(--shadow-line);
     max-width: 850px;
-    width: 100%;
-    margin: 8vh auto;
+    max-height: 90vh;
+    width: calc(100% - 10vw);
+    margin: 5vh auto;
     animation: modal-show .5s;
     animation-fill-mode: both;
-    position: relative;
+    position: fixed;
     display: none;
+    flex-direction: column;
+    box-sizing: border-box;
+    top: 0;
+    left: 0;
+    right: 0;
 
     &[open] {
-      display: block;
+      display: flex;
     }
 
     & > .ola_modal-header {
-        padding: var(--inner-gap) var(--inner-gap) 0;
+        padding: var(--inner-gap);
     }
+}
+
+.ola_modal::backdrop {
+    background: #0006;
+}
+.ola_modal + .backdrop {
+    background: #0006;
+}
+.ola_modal + .backdrop,
+._dialog_overlay {
+  position: fixed;
+  top: 0; right: 0; bottom: 0; left: 0;
 }
 
 .ola_modal-header {
@@ -25,9 +43,16 @@
   grid-template-areas: "title" "intro";
   grid-template-columns: 1fr auto;
   grid-column-gap: var(--size-6);
+  flex: 0 0 auto;
+
   &.has-extra {
-      grid-template-areas: "title title" "intro extra";
-  }
+        grid-template-areas: "title" "intro" "extra";
+
+        @media (--from-width-2) {
+            grid-template-areas: "title extra" "intro extra";
+            grid-template-columns: 1fr auto;
+        }
+    }
 }
 
 .ola_modal-extra {
@@ -47,32 +72,18 @@
 }
 .ola_modal-intro {
     grid-area: intro;
-    margin-top: var(--size-3);
+    margin: var(--size-3) 0 0;
     font: var(--font-callout);
     color: var(--gray);
 }
 .ola_modal-content {
-    padding: var(--size-8);
+    padding: var(--inner-gap);
+    min-height: 0;
+    overflow-y: auto;
 }
 .ola_modal-footer {
-    padding: 0 var(--size-8) var(--size-7);
-}
-.ola_modal-overlay {
-    background: #0006;
-    position: fixed !important;
-    z-index: 10;
-    margin: 0 !important;
-    top: 0 !important;
-    left: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
-    box-sizing: border-box;
-    padding: var(--size-8);
-    overflow: auto;
-    animation: overlay-show .5s;
-    @media (--to-width-1) {
-        padding: var(--size-4);
-    }
+    padding: 0  var(--inner-gap) var(--inner-gap);
+    flex: 0 0 auto;
 }
 
 @keyframes modal-show {
@@ -86,31 +97,4 @@
     to {
         transform: translateY(0);
     }
-}
-
-@keyframes overlay-show {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-// polyfill
-
-dialog + .backdrop {
-  position: fixed;
-  top: 0; right: 0; bottom: 0; left: 0;
-}
-
-._dialog_overlay {
-  position: fixed;
-  top: 0; right: 0; bottom: 0; left: 0;
-}
-
-dialog.fixed {
-  position: fixed;
-  top: 50%;
-  transform: translate(0, -50%);
 }

--- a/src/Modal/style.css
+++ b/src/Modal/style.css
@@ -16,6 +16,7 @@
     top: 0;
     left: 0;
     right: 0;
+    padding: 0;
 
     &[open] {
       display: flex;

--- a/src/Modal/test.js
+++ b/src/Modal/test.js
@@ -9,7 +9,7 @@ import renderer from 'react-test-renderer'
 it('Default Modal', () => {
   const tree = renderer
     .create(
-      <Modal onClose={() => alert('onClick event')}>
+      <Modal open onClose={() => alert('onClick event')}>
         <ModalHeader
           title="Modal Header"
           intro={<><strong>Lorem ipsum</strong> for testing intro</>}

--- a/src/hooks/useEventListener.js
+++ b/src/hooks/useEventListener.js
@@ -8,7 +8,7 @@ const useEventListener = (ref, event, func) => {
       // Unbind the event listener on clean up
       ref && ref.removeEventListener(event, func)
     }
-  })
+  }, [])
 }
 
 export default useEventListener

--- a/src/hooks/useEventListener.js
+++ b/src/hooks/useEventListener.js
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+
+const useEventListener = (ref, event, func) => {
+  useEffect(() => {
+    // Bind the event listener
+    ref && ref.addEventListener(event, func)
+    return () => {
+      // Unbind the event listener on clean up
+      ref && ref.removeEventListener(event, func)
+    }
+  })
+}
+
+export default useEventListener


### PR DESCRIPTION
1 -It's no longer necessary to create the component by adding `<div className="ola_modal-overlay"`, this is implicit in the `<Modal` component ... Note that it's a breaking change
2 - Ability to close the modal by clicking out.
3 - Ability to close the modal by pressing ESC key.
4 - Replaced `<section>` by `<dialog>` with `open` dispacher prop.

