### PR TITLE
added variants to buttonIcon

### DIFF
--- a/src/ButtonIcon/__snapshots__/test.js.snap
+++ b/src/ButtonIcon/__snapshots__/test.js.snap
@@ -2,7 +2,25 @@
 
 exports[`Close Button icon 1`] = `
 <button
-  className="ola_buttonIcon"
+  className="ola_buttonIcon is-normal"
+>
+  <svg
+    className="ola_icon is-medium"
+    fillRule="evenodd"
+    height="28"
+    viewBox="0 0 28 28"
+    width="28"
+  >
+    <path
+      d="M22.92 4c.296 0 .55.105.762.314.212.21.318.462.318.758s-.106.55-.318.762l-8.17 8.174 8.17 8.166c.212.212.318.464.318.754 0 .296-.106.549-.318.758-.212.21-.466.314-.762.314s-.547-.103-.753-.31l-8.171-8.166-8.163 8.166c-.206.207-.46.31-.761.31a1.04 1.04 0 0 1-.758-.31A1.02 1.02 0 0 1 4 22.936c0-.301.103-.555.31-.762l8.17-8.166-8.17-8.174A1.026 1.026 0 0 1 4 5.08c0-.296.105-.55.314-.762.21-.212.462-.318.758-.318.295 0 .55.106.761.318l8.163 8.174 8.17-8.174A1.03 1.03 0 0 1 22.92 4z"
+    />
+  </svg>
+</button>
+`;
+
+exports[`Destructive button icon 1`] = `
+<button
+  className="ola_buttonIcon is-destructive"
 >
   <svg
     className="ola_icon is-medium"

--- a/src/ButtonIcon/index.js
+++ b/src/ButtonIcon/index.js
@@ -23,7 +23,7 @@ ButtonIcon.propTypes = {
   /** Render ButtonIcon with any html tag */
   as: PT.string,
   /** Button variants */
-  variant: PT.oneOf(['normal', 'destructive']),
+  variant: PT.oneOf(['normal', 'destructive', 'chevron']),
   /** Extra className */
   extraClass: PT.string,
   /** Childen nodes */

--- a/src/ButtonIcon/index.js
+++ b/src/ButtonIcon/index.js
@@ -3,9 +3,15 @@ import {default as PT} from 'prop-types'
 import { getElementType } from '../utils'
 import cx from 'classnames'
 
-const ButtonIcon = ({ as, extraClass, children, ...props }) => {
+const ButtonIcon = ({ as, extraClass, children, variant, ...props }) => {
   const ElementType = getElementType(ButtonIcon, { as: as, ...props })
-  return (<ElementType {...props} className={cx('ola_buttonIcon', extraClass)}>{children}</ElementType>)
+  delete props['as']
+  const styles = cx(
+    'ola_buttonIcon',
+    {[`is-${variant}`]: variant },
+    extraClass
+  )
+  return (<ElementType {...props} className={styles}>{children}</ElementType>)
 }
 
 ButtonIcon.defaultProps = {
@@ -15,6 +21,8 @@ ButtonIcon.defaultProps = {
 ButtonIcon.propTypes = {
   /** Render ButtonIcon with any html tag */
   as: PT.string,
+  /** Button variants */
+  variant: PT.oneOf(['normal', 'destructive']),
   /** Extra className */
   extraClass: PT.string,
   /** Childen nodes */

--- a/src/ButtonIcon/index.js
+++ b/src/ButtonIcon/index.js
@@ -15,7 +15,8 @@ const ButtonIcon = ({ as, extraClass, children, variant, ...props }) => {
 }
 
 ButtonIcon.defaultProps = {
-  as: 'button'
+  as: 'button',
+  variant: null
 }
 
 ButtonIcon.propTypes = {

--- a/src/ButtonIcon/index.js
+++ b/src/ButtonIcon/index.js
@@ -8,7 +8,7 @@ const ButtonIcon = ({ as, extraClass, children, variant, ...props }) => {
   delete props['as']
   const styles = cx(
     'ola_buttonIcon',
-    {[`is-${variant}`]: variant },
+    `is-${variant}`,
     extraClass
   )
   return (<ElementType {...props} className={styles}>{children}</ElementType>)
@@ -16,7 +16,7 @@ const ButtonIcon = ({ as, extraClass, children, variant, ...props }) => {
 
 ButtonIcon.defaultProps = {
   as: 'button',
-  variant: null
+  variant: 'normal'
 }
 
 ButtonIcon.propTypes = {

--- a/src/ButtonIcon/stories.js
+++ b/src/ButtonIcon/stories.js
@@ -12,8 +12,8 @@ storiesOf('ButtonIcon')
     <figure>
       <ButtonIcon
         onClick={action('onClick event')}
-        variant={radios('Variant', ['normal', 'destructive'], 'normal')}>
-        <Icon name="close" />
+        variant={radios('Variant', ['normal', 'destructive', 'chevron'], 'normal')}>
+        <Icon name="user" />
       </ButtonIcon>
     </figure>
   ))

--- a/src/ButtonIcon/stories.js
+++ b/src/ButtonIcon/stories.js
@@ -1,15 +1,20 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
+import { radios } from '@storybook/addon-knobs'
 
 import Tag from '../Tag'
 import Icon from '../Icon'
 import ButtonIcon from './'
 
 storiesOf('ButtonIcon')
-  .add('Default', () => (
+  .add('Viewer', () => (
     <figure>
-      <ButtonIcon onClick={action('onClick event')}><Icon name="close" /></ButtonIcon>
+      <ButtonIcon
+        onClick={action('onClick event')}
+        variant={radios('Variant', ['normal', 'destructive'], 'normal')}>
+          <Icon name="close" />
+      </ButtonIcon>
     </figure>
   ))
   .add('Tag with Button', () => (

--- a/src/ButtonIcon/stories.js
+++ b/src/ButtonIcon/stories.js
@@ -13,7 +13,7 @@ storiesOf('ButtonIcon')
       <ButtonIcon
         onClick={action('onClick event')}
         variant={radios('Variant', ['normal', 'destructive'], 'normal')}>
-          <Icon name="close" />
+        <Icon name="close" />
       </ButtonIcon>
     </figure>
   ))

--- a/src/ButtonIcon/style.css
+++ b/src/ButtonIcon/style.css
@@ -1,5 +1,5 @@
 .ola_buttonIcon {
-    --color: currentColor;
+    --color: var(--gray);
     --background: transparent;
     --color-hover: var(--black);
     --background-hover: var(--gray-xlight);
@@ -42,6 +42,13 @@
 
     & .ola_icon.is-medium {
         padding: var(--size-3);
+    }
+
+    &.is-destructive {
+        --color: var(--error);
+        --shadow-focus: var(--error-focus);
+        --color-hover: var(--error-dark);
+        --background-active: var(--error-focus);
     }
 }
 

--- a/src/ButtonIcon/style.css
+++ b/src/ButtonIcon/style.css
@@ -50,5 +50,15 @@
         --color-hover: var(--error-dark);
         --background-active: var(--error-focus);
     }
+
+    &.is-chevron {
+        background-repeat: no-repeat;
+        background-position: right center;
+        padding-right: var(--size-7);
+        border-radius: var(--radius-big);
+
+        /* Chevron gray */
+        background-image: url('data:image/svg+xml;charset=UTF-8,<svg width="44px" height="44px" viewBox="0 0 44 44" version="1.1" xmlns="http://www.w3.org/2000/svg"><path d="M22,23.5857864 L27.2928932,18.2928932 C27.6834175,17.9023689 28.3165825,17.9023689 28.7071068,18.2928932 C29.0976311,18.6834175 29.0976311,19.3165825 28.7071068,19.7071068 L22.7071068,25.7071068 C22.3165825,26.0976311 21.6834175,26.0976311 21.2928932,25.7071068 L15.2928932,19.7071068 C14.9023689,19.3165825 14.9023689,18.6834175 15.2928932,18.2928932 C15.6834175,17.9023689 16.3165825,17.9023689 16.7071068,18.2928932 L22,23.5857864 Z" fill="%2357657a"></path></svg>');
+    }
 }
 

--- a/src/ButtonIcon/test.js
+++ b/src/ButtonIcon/test.js
@@ -14,3 +14,14 @@ it('Close Button icon', () => {
 
   expect(tree).toMatchSnapshot()
 })
+it('Destructive button icon', () => {
+  const tree = renderer
+    .create(
+      <ButtonIcon variant="destructive">
+        <Icon name="close" />
+      </ButtonIcon>
+    )
+    .toJSON()
+
+  expect(tree).toMatchSnapshot()
+})

--- a/src/Modal/__snapshots__/test.js.snap
+++ b/src/Modal/__snapshots__/test.js.snap
@@ -40,7 +40,7 @@ exports[`Default Modal 1`] = `
     This is the footer
   </div>
   <button
-    className="ola_buttonIcon ola_modal-close"
+    className="ola_buttonIcon is-normal ola_modal-close"
     onClick={[Function]}
     type="button"
   >


### PR DESCRIPTION
ButtonIcon component have now two variants: `normal` and `destructive`, to display the icon in gray (by default) or red.