### PR TITLE
Added narrow and reversed-narrow variants to ButtonGroup

### DIFF
--- a/src/ButtonGroup/index.js
+++ b/src/ButtonGroup/index.js
@@ -6,7 +6,8 @@ const ButtonGroup = ({ variant, className, children, ...props }) => {
   const styles = cx(
     'ola_buttonGroup',
     { 'is-center': variant && (variant == 'center' || variant == 'reversed-center') },
-    { 'is-reversed': variant && (variant == 'reversed' || variant == 'reversed-center') },
+    { 'is-reversed': variant && (variant == 'reversed' || variant == 'reversed-center' || variant == 'reversed-narrow') },
+    { 'is-narrow': variant && (variant == 'narrow' || variant == 'reversed-narrow') },
     className
   )
   return (
@@ -23,7 +24,7 @@ ButtonGroup.defaultProps = {
 
 ButtonGroup.propTypes = {
   /** Variants: Center or Reversed button order ( helper for tabulation problems ) */
-  variant: PT.oneOf(['default', 'reversed', 'center', 'reversed-center']),
+  variant: PT.oneOf(['default', 'reversed', 'center', 'reversed-center', 'narrow', 'reversed-narrow']),
   /** Extra className */
   className: PT.string,
   /** Childen nodes */

--- a/src/ButtonGroup/stories.js
+++ b/src/ButtonGroup/stories.js
@@ -8,7 +8,14 @@ import ButtonGroup from './'
 
 storiesOf('ButtonGroup')
   .add('Viewer', () => (
-    <ButtonGroup variant={radios('Variant', ['default', 'center', 'reversed', 'reversed-center'], 'default')} style={{width: '500px', border: 'solid 1px'}}>
+    <ButtonGroup variant={radios('Variant', [
+      'default',
+      'center',
+      'reversed',
+      'reversed-center',
+      'narrow',
+      'reversed-narrow'
+    ], 'default')} style={{width: '500px', border: 'solid 1px'}}>
       <Button variant='primary' onClick={action('onClick event')}>Accept</Button>
       <Button variant='secondary' onClick={action('onClick event')}>Cancel</Button>
     </ButtonGroup>

--- a/src/ButtonGroup/style.css
+++ b/src/ButtonGroup/style.css
@@ -20,22 +20,28 @@
       justify-content: center;
     }
 
+    &.is-narrow {
+      flex: 1 1 auto;
+    }
+
     @media (--from-width-1) {
-        flex-direction: row;
-        align-items: center;
-
-        & .ola_button + .ola_button {
-            margin-left: var(--column-gap-1);
-            margin-top: 0;
-        }
-
-        &.is-reversed {
-            flex-direction: row-reverse;
+        &:not(.is-narrow) {
+            flex-direction: row;
+            align-items: center;
 
             & .ola_button + .ola_button {
-                margin-left: 0;
-                margin-bottom: 0;
-                margin-right: var(--column-gap-1);
+                margin-left: var(--column-gap-1);
+                margin-top: 0;
+            }
+
+            &.is-reversed {
+                flex-direction: row-reverse;
+
+                & .ola_button + .ola_button {
+                    margin-left: 0;
+                    margin-bottom: 0;
+                    margin-right: var(--column-gap-1);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR fixed #138 
Added two more variants to `ButtonGroup` component for these cases in which we want buttons are in vertical, no matter the media queries.

An use case for this is this example:
<img width="1030" alt="imaxe" src="https://user-images.githubusercontent.com/377873/82682232-3d1ece80-9c4f-11ea-9d53-00d2a0759b0d.png">

When the ButtonGroup is in a modal with `narrow` variant and the buttons does not fit in the available space, we can force the buttons to look as if they were in mobile:

<img width="1032" alt="imaxe" src="https://user-images.githubusercontent.com/377873/82682459-9555d080-9c4f-11ea-97ea-127080eadb8f.png">