### PR TITLE
Added variant and selected props to MenuOption

### DIFF
--- a/src/Menu/Option.js
+++ b/src/Menu/Option.js
@@ -3,12 +3,18 @@ import {default as PT} from 'prop-types'
 import cx from 'classnames'
 import { getElementType } from '../utils'
 
-const MenuOption = ({ as, className, separator, children, ...props }) => {
+const MenuOption = ({ as, className, separator, children, variant, selected, ...props }) => {
   const ElementType = getElementType(Option, { as: as, ...props })
   delete props['as']
   return (
     <li className={cx(separator && 'ola_menu-separator')}>
-      <ElementType className={ cx('ola_menu-option', className) } {...props}>
+      <ElementType className={ cx(
+        'ola_menu-option',
+        className,
+        {
+          [`is-${variant}`]: variant,
+          ['is-selected']: selected 
+        }) } {...props}>
         {children}
       </ElementType>
     </li>
@@ -24,8 +30,12 @@ MenuOption.defaultProps = {
 MenuOption.propTypes = {
   /** Render Item with any html tag */
   as: PT.string,
+  /** Option variants */
+  variant: PT.oneOf(['nav']),
   /** Separator */
   separator: PT.bool,
+  /** Selected */
+  selected: PT.bool,
   /** Extra className */
   className: PT.string,
   /** Childen nodes */

--- a/src/Menu/__snapshots__/test.js.snap
+++ b/src/Menu/__snapshots__/test.js.snap
@@ -9,7 +9,6 @@ exports[`Default Menu with Options 1`] = `
   >
     <button
       className="ola_menu-option"
-      variant={null}
     >
       Option 1
     </button>
@@ -19,7 +18,6 @@ exports[`Default Menu with Options 1`] = `
   >
     <button
       className="ola_menu-option"
-      variant={null}
     >
       Option 2
     </button>
@@ -36,7 +34,6 @@ exports[`Default Menu with separator items 1`] = `
   >
     <button
       className="ola_menu-option"
-      variant={null}
     >
       Option 1
     </button>
@@ -46,7 +43,6 @@ exports[`Default Menu with separator items 1`] = `
   >
     <button
       className="ola_menu-option"
-      variant={null}
     >
       Option 2
     </button>
@@ -56,7 +52,6 @@ exports[`Default Menu with separator items 1`] = `
   >
     <button
       className="ola_menu-option"
-      variant={null}
     >
       Option 3
     </button>
@@ -66,7 +61,6 @@ exports[`Default Menu with separator items 1`] = `
   >
     <button
       className="ola_menu-option"
-      variant={null}
     >
       Option 4
     </button>
@@ -84,7 +78,6 @@ exports[`Options are links 1`] = `
     <button
       className="ola_menu-option"
       href="link1"
-      variant={null}
     >
       Option 1
     </button>
@@ -95,7 +88,6 @@ exports[`Options are links 1`] = `
     <button
       className="ola_menu-option"
       href="link2"
-      variant={null}
     >
       Option 2
     </button>

--- a/src/Menu/stories.js
+++ b/src/Menu/stories.js
@@ -46,3 +46,24 @@ storiesOf('Menu')
       </Tooltip>
     </figure>
   ))
+  .add('Aside', () => (
+    <figure>
+      <Menu>
+        <MenuOption href="#" variant="nav" selected>
+          <strong>General</strong>
+        </MenuOption>
+        <MenuOption href="#" variant="nav">
+          <strong>Keywords</strong>
+        </MenuOption>
+        <MenuOption href="#" variant="nav">
+          <strong>Competitors</strong>
+        </MenuOption>
+        <MenuOption href="#" variant="nav">
+          <strong>Notifications</strong>
+        </MenuOption>
+        <MenuOption href="#" variant="nav">
+          <strong>Connections</strong>
+        </MenuOption>
+      </Menu>
+    </figure>
+  ))

--- a/src/Menu/style.css
+++ b/src/Menu/style.css
@@ -24,10 +24,20 @@
         border: 0;
     }
 
+    &.is-nav {
+        --color: var(--accent);
+        border-top: solid 1px var(--gray-xlight);
+    }
+
+    &.is-selected,
     &:hover,
     &:focus {
         --color: var(--black);
         --background: var(--gray-xlight);
+    }
+
+    &.is-selected {
+        border-left: solid var(--size-1) var(--gray-light);
     }
 
     &:active {


### PR DESCRIPTION
`MenuOption` component has two new properties:

- `variant`: At this moment, there's only one variant: `nav` that change the text color to blue.
- `selected` (true|false): To mark the option as selected. 

With these props we can create aside menus like this:

<img width="780" alt="imaxe" src="https://user-images.githubusercontent.com/377873/89322311-5ba83980-d684-11ea-8795-6608390e8cd0.png">
