### PR TITLE
multiline chart

### DIFF
--- a/src/ChartLine/Label.js
+++ b/src/ChartLine/Label.js
@@ -5,7 +5,7 @@ import cx from 'classnames'
 const Label = ({ value, children, className }) => {
   const styles = cx('ola_chartLine-label', className)
   return (
-    <div className={styles} style={{ '--value': value }}>
+    <div className={styles} style={{ '--value': Math.max(...value) }}>
       { children }
     </div>
   )
@@ -18,7 +18,7 @@ Label.defaultProps = {
 
 Label.propTypes = {
   /** Value between 0 and 1 */
-  value: PT.number,
+  value: PT.arrayOf(PT.number),
   /** Extra className */
   className: PT.string,
   /** Childen nodes */

--- a/src/ChartLine/Label.js
+++ b/src/ChartLine/Label.js
@@ -12,13 +12,13 @@ const Label = ({ value, children, className }) => {
 }
 
 Label.defaultProps = {
-  value: 0,
+  value: [0],
   className: null
 }
 
 Label.propTypes = {
   /** Value between 0 and 1 */
-  value: PT.arrayOf(PT.number),
+  value: PT.arrayOf(PT.number).isRequired,
   /** Extra className */
   className: PT.string,
   /** Childen nodes */

--- a/src/ChartLine/__snapshots__/test.js.snap
+++ b/src/ChartLine/__snapshots__/test.js.snap
@@ -53,13 +53,13 @@ exports[`ChartLine and ChartLineLabel 1`] = `
   >
     <path
       className="ola_chartLine-svg-background"
-      d="M 0 0 M 0 NaN L 100 NaN V 0 H 0 Z"
+      d="M 0 0 M 0 80 L 12.5 80 L 37.5 125 L 62.5 140 L 87.5 5 L 100 5 V 0 H 0 Z"
       strokeLinejoin="round"
       vectorEffect="non-scaling-stroke"
     />
     <path
       className="ola_chartLine-svg-line"
-      d="M 0 0 M 0 NaN L 100 NaN"
+      d="M 0 0 M 0 80 L 12.5 80 L 37.5 125 L 62.5 140 L 87.5 5 L 100 5"
       strokeLinejoin="round"
       vectorEffect="non-scaling-stroke"
     />
@@ -81,13 +81,7 @@ exports[`Default ChartLine 1`] = `
   >
     <path
       className="ola_chartLine-svg-background"
-      d="M 0 0 M 0 NaN L 100 NaN V 0 H 0 Z"
-      strokeLinejoin="round"
-      vectorEffect="non-scaling-stroke"
-    />
-    <path
-      className="ola_chartLine-svg-line"
-      d="M 0 0 M 0 NaN L 100 NaN"
+      d="M 0 0 M 0 0 L 100 0 V 0 H 0 Z"
       strokeLinejoin="round"
       vectorEffect="non-scaling-stroke"
     />

--- a/src/ChartLine/__snapshots__/test.js.snap
+++ b/src/ChartLine/__snapshots__/test.js.snap
@@ -81,7 +81,7 @@ exports[`Default ChartLine 1`] = `
   >
     <path
       className="ola_chartLine-svg-background"
-      d="M 0 0 M 0 0 L 100 0 V 0 H 0 Z"
+      d="M 0 0 M 0 155 L 100 155 V 0 H 0 Z"
       strokeLinejoin="round"
       vectorEffect="non-scaling-stroke"
     />

--- a/src/ChartLine/index.js
+++ b/src/ChartLine/index.js
@@ -1,30 +1,41 @@
 import React from 'react'
 import {default as PT} from 'prop-types'
 
-const ChartLine = ({ children, values }) => {
-  const draw = drawPath(values)
-  const lineD = `M 0 0 ${draw}`
-  const fillD = `M 0 0 ${draw} V 0 H 0 Z`
+const ChartLine = ({ children, ranges, colors }) => {
+  const lines = separateRanges(ranges)
+  const max = ranges.map(range => Math.max(...range))
+  const fillD = `M 0 0 ${drawPath(max)} V 0 H 0 Z`
 
   return (
     <div className="ola_chartLine">
       { children }
-
-      <svg role="img" viewBox="0 0 100 160" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" className="ola_chartLine-svg">
-        <path d={fillD} vectorEffect="non-scaling-stroke" strokeLinejoin="round" className="ola_chartLine-svg-background" />
-        <path d={lineD} vectorEffect="non-scaling-stroke" strokeLinejoin="round"  className="ola_chartLine-svg-line" />
-      </svg>
+      {
+        <svg role="img" viewBox="0 0 100 160" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" className="ola_chartLine-svg">
+          <path d={fillD} vectorEffect="non-scaling-stroke" strokeLinejoin="round" className="ola_chartLine-svg-background" />
+          {
+            lines.map((line, index) => {
+              const draw = drawPath(line)
+              const lineD = `M 0 0 ${draw}`
+              const style = colors[index] ? {'--color': colors[index]} : undefined
+              return <path key={index} d={lineD} vectorEffect="non-scaling-stroke" strokeLinejoin="round" className="ola_chartLine-svg-line" style={style} />
+            })
+          }
+        </svg>
+      }
     </div>
   )
 }
 
 ChartLine.defaultProps = {
-  values: [],
+  ranges: [],
+  colors: [],
 }
 
 ChartLine.propTypes = {
-  /** All values */
-  values: PT.arrayOf(PT.number).isRequired,
+  /** All range values */
+  ranges: PT.arrayOf(PT.arrayOf(PT.number)).isRequired,
+  /** All color values */
+  colors: PT.arrayOf(PT.string),
   /** Childen nodes */
   children: PT.oneOfType([
     PT.arrayOf(PT.node),
@@ -51,4 +62,12 @@ function drawPath(values) {
 
 function getYPosition(value) {
   return 150 - (value * 150) + 5
+}
+
+function separateRanges(ranges) {
+  return new Array(ranges[0].length)
+    .fill([])
+    .map((value, index) =>
+      ranges.map((range) => range[index])
+    )
 }

--- a/src/ChartLine/index.js
+++ b/src/ChartLine/index.js
@@ -1,13 +1,28 @@
 import React from 'react'
 import {default as PT} from 'prop-types'
+import cx from 'classnames'
+import Label from './Label'
 
-const ChartLine = ({ children, ranges, colors }) => {
+const ChartLine = ({ status, children, ranges, colors, className }) => {
+  const styles = cx(
+    'ola_chartLine',
+    { 'ola-skeleton': status !== 'loaded' },
+    { 'is-loading': status === 'loading' },
+    className
+  )
+
+  if (status !== 'loaded') {
+    ranges = [[0.6], [0.3], [0.8]]
+    colors = []
+    children = ranges.map((value, index) => <Label value={ value } key={ index }></Label>)
+  }
+
   const lines = separateRanges(ranges)
   const max = ranges.map(range => Math.max(...range))
   const fillD = `M 0 0 ${drawPath(max)} V 0 H 0 Z`
 
   return (
-    <div className="ola_chartLine">
+    <div className={ styles }>
       { children }
       {
         <svg role="img" viewBox="0 0 100 160" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" className="ola_chartLine-svg">
@@ -29,6 +44,8 @@ const ChartLine = ({ children, ranges, colors }) => {
 ChartLine.defaultProps = {
   ranges: [],
   colors: [],
+  status: 'loaded',
+  className: null,
 }
 
 ChartLine.propTypes = {
@@ -36,11 +53,15 @@ ChartLine.propTypes = {
   ranges: PT.arrayOf(PT.arrayOf(PT.number)).isRequired,
   /** All color values */
   colors: PT.arrayOf(PT.string),
+  /** Chart status */
+  status: PT.oneOf(['loaded', 'loading', 'empty']),
+  /** Extra className */
+  className: PT.string,
   /** Childen nodes */
   children: PT.oneOfType([
     PT.arrayOf(PT.node),
     PT.node
-  ]).isRequired
+  ])
 }
 
 export default ChartLine
@@ -61,10 +82,17 @@ function drawPath(values) {
 }
 
 function getYPosition(value) {
+  if (!value) {
+    return 0
+  }
   return 150 - (value * 150) + 5
 }
 
 function separateRanges(ranges) {
+  if (!ranges.length) {
+    return []
+  }
+
   return new Array(ranges[0].length)
     .fill([])
     .map((value, index) =>

--- a/src/ChartLine/stories.js
+++ b/src/ChartLine/stories.js
@@ -7,7 +7,6 @@ const mockData = [
   {
     value: 50,
     label: '50 keywords',
-    color: 'green'
   },
   {
     value: 20,
@@ -23,6 +22,32 @@ const mockData = [
   }
 ]
 
+const mockData2 = [
+  {
+    value: 23,
+    label: '23 sites',
+  },
+  {
+    value: 10,
+    label: '10 sites',
+  },
+  {
+    value: 0,
+    label: '0 sites',
+  },
+  {
+    value: 90,
+    label: '90 sites',
+  }
+]
+
+const colors = [
+  'var(--brand)',
+  'var(--error)',
+  'pink',
+  'var(--success)',
+]
+
 export default {
   title: 'ChartLine',
   component: ChartLine,
@@ -31,21 +56,35 @@ export default {
 
 export const Base = () => {
   const ranges = getRanges(mockData.map( data => data.value ))
-
   return (
-    <ChartLine values={ranges}>
+    <ChartLine ranges={ranges} colors={colors}>
       { mockData.map((row, idx) => 
-        <ChartLineLabel key={idx} value={ranges[idx]}>{row.label}</ChartLineLabel>
+        <ChartLineLabel key={idx} value={ranges[idx]}>
+          {row.label}
+        </ChartLineLabel>
       )}
     </ChartLine>
   )
 }
- 
+
+export const Multiple = () => {
+  const ranges = getRanges(mockData.map( data => data.value ), mockData2.map( data => data.value ))
+  return (
+    <ChartLine ranges={ranges} colors={colors}>
+      { mockData.map((row, idx) => 
+        <ChartLineLabel key={idx} value={ranges[idx]}>
+          {row.label} <br/> from {mockData2[idx].label}
+        </ChartLineLabel>
+      )}
+    </ChartLine>
+  )
+}
+
 export const HtmlLabels = () => {
   const ranges = getRanges(mockData.map( data => data.value ))
 
   return (
-    <ChartLine values={ranges}>
+    <ChartLine ranges={ranges}>
       { mockData.map((row, idx) => 
         <ChartLineLabel key={idx} value={ranges[idx]}>
           <div><strong>{row.label}</strong><br />{row.label}</div>

--- a/src/ChartLine/stories.js
+++ b/src/ChartLine/stories.js
@@ -51,7 +51,21 @@ const colors = [
 export default {
   title: 'ChartLine',
   component: ChartLine,
-  args: {}
+  args: {
+    ranges: getRanges(mockData.map( data => data.value ))
+  }
+}
+
+export const Empty = (args) => {
+  return (
+    <ChartLine {...args}>
+      { mockData.map((row, idx) => 
+        <ChartLineLabel key={idx} value={args.ranges[idx]}>
+          {row.label}
+        </ChartLineLabel>
+      )}
+    </ChartLine>
+  )
 }
 
 export const Base = () => {

--- a/src/ChartLine/style.css
+++ b/src/ChartLine/style.css
@@ -1,11 +1,24 @@
 .ola_chartLine {
     --height: 150px;
-    --color: var(--gray-light);
+    --color: var(--brand);
 
     display: flex;
     position: relative;
     text-align: center;
     align-items: flex-end;
+
+    &.ola-skeleton {
+        --color: var(--gray-xlight);
+
+        & .ola_chartLine-label::before {
+            visibility: hidden;
+        }
+        &.is-loading .ola_chartLine-svg {
+            background: linear-gradient(to right, rgba(255, 255, 255, 0) 40%, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) 60%), linear-gradient(to bottom, var(--gray-xlight), var(--gray-xlight) 66%, var(--white));
+            background-size: 800px 100%;
+            animation: loadingSkeleton 2s linear infinite;
+        }
+    }
 }
 
 .ola_chartLine-svg {
@@ -22,7 +35,6 @@
     stroke: none;
 }
 .ola_chartLine-svg-line {
-    --color: var(--brand);
     fill: none;
     stroke: var(--color);
     stroke-width: 4px;
@@ -39,7 +51,7 @@
         content: "";
         display: block;
         margin: 14px auto 0;
-        border: solid 4px var(--brand);
+        border: solid 4px var(--color);
         background: white;
         width: 8px;
         height: 8px;

--- a/src/ChartLine/style.css
+++ b/src/ChartLine/style.css
@@ -14,7 +14,7 @@
     left: 0;
     width: 100%;
     height: calc(var(--height) + 10px);
-    background: linear-gradient(to bottom, var(--gray-light), var(--gray-xlight) 66%, var(--white));
+    background: linear-gradient(to bottom, var(--gray-xlight), var(--gray-xlight) 66%, var(--white));
     padding-bottom: 28px;
 }
 .ola_chartLine-svg-background {
@@ -22,8 +22,9 @@
     stroke: none;
 }
 .ola_chartLine-svg-line {
+    --color: var(--brand);
     fill: none;
-    stroke: var(--brand);
+    stroke: var(--color);
     stroke-width: 4px;
 }
 

--- a/src/ChartLine/test.js
+++ b/src/ChartLine/test.js
@@ -41,7 +41,7 @@ it('ChartLine and ChartLineLabel', () => {
   const ranges = getRanges(mockData.map(data => data.value))
   const tree = renderer
     .create(
-      <ChartLine>
+      <ChartLine ranges={ ranges }>
         { mockData.map((row, idx) => 
           <ChartLineLabel key={idx} value={ranges[idx]}>{row.label}</ChartLineLabel>
         )}

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,7 +33,13 @@ export { getElementType }
 const normalizeRange = (val, max, min = 0) => (val - min) / (max - min)
 export { normalizeRange }
 
-export function getRanges(values) {
-  const max = Math.max(...values)
-  return values.map(value => normalizeRange(value, max))
+export function getRanges(...rows) {
+  let max = 0
+  rows.forEach((row) => max = Math.max(max, ...row))
+
+  return new Array(rows[0].length)
+    .fill([])
+    .map((value, index) =>
+      rows.map((row) => normalizeRange(row[index], max))
+    )
 }


### PR DESCRIPTION
Some breaking changes with the previous Line chart:
- `values` has been renamed to `ranges` (for naming consistency with `getRanges()` function in utils
- The `getRanges()` function returns one array for every value. For example:

```js
const ranges = getRanges(data.map(row => row.value))
console.log(ranges);
// Before: [1, 0.2, 0.3, 0.4]
// Now: [[1], [0.2], [0.3], [0.4]]
```

To add more lines, use additional arguments to getRanges:

```js
const ranges = getRanges(
    data1.map(row => row.value),
    data2.map(row => row.value)
)
console.log(ranges);
// [[1, 0.2], [0.2, 0.4], [0.3, 0.6], [0.4, 0.7]]
```

I've added also a `colors` prop, so you can customize the color of every line:

```jsx
const ranges = getRanges(
    data1.map(row => row.value),
    data2.map(row => row.value)
)
const colors = ["red", "var(--brand)"];

<ChartLine ranges={ranges} colors={colors}>
      { data1.map((row, idx) => 
        <ChartLineLabel key={idx} value={ranges[idx]}>
          {data1.label} <br>
          {data2[idx].label} 
        </ChartLineLabel>
      )}
    </ChartLine>
```