### PR TITLE
Feature/progress bar indeterminate

### DIFF
--- a/src/ProgressBar/style.css
+++ b/src/ProgressBar/style.css
@@ -1,4 +1,6 @@
 .ola_progressBar {
+  --color: var(--brand);
+  --background: var(--white);
 
   width: 100%;
   display: flex;
@@ -10,7 +12,6 @@
     flex-wrap: nowrap;
     white-space: nowrap;
   }
-
 }
 
 .ola_progressBar-description {
@@ -25,15 +26,12 @@
 }
 
 .ola_progressBar progress {
-
-    --color: var(--brand);
-
     appearance: none;
     border: solid 1px var(--color);
     height: 10px;
     width: 100%;
     min-width: 100px;
-    background: var(--white);
+    background: var(--background);
     border-radius: 6px;
     box-sizing: border-box;
 
@@ -46,15 +44,18 @@
     &::-moz-progress-bar {
         background: var(--color);
     }
+
+    &:indeterminate {
+        --color: var(--gray-xlight);
+        --background: var(--gray-xlight);
+    }
 }
 
 .ola_progressBar meter {
-    --color: var(--brand);
-
     -moz-appearance: none;
     border-radius: 6px;
     box-sizing: border-box;
-    background: var(--white);
+    background: var(--background);
     width: 100%;
     height: 10px;
 
@@ -76,10 +77,10 @@
         height: 10px;
         border-radius: 6px;
         background: none;
-        border: solid 1px var(--brand);
+        border: solid 1px var(--color);
     }
     &::-webkit-meter-optimum-value {
-        background: var(--brand);
+        background: var(--color);
     }
     &::-webkit-meter-suboptimum-value {
         background: var(--warning);
@@ -87,10 +88,14 @@
     &::-webkit-meter-even-less-good-value {
         background: var(--error);
     }
+    &:not(value) {
+        --color: var(--gray-xlight);
+        --background: var(--gray-xlight);
+    }
 }
 /* Only firefox */
 @-moz-document url-prefix() {
     .ola_progressBar meter {
-        border: solid 1px var(--brand);
+        border: solid 1px var(--color);
     }
 }

--- a/src/ProgressBar/style.css
+++ b/src/ProgressBar/style.css
@@ -1,6 +1,7 @@
 .ola_progressBar {
   --color: var(--brand);
   --background: var(--white);
+  --color-empty: var(--gray-xlight);
 
   width: 100%;
   display: flex;
@@ -46,8 +47,8 @@
     }
 
     &:indeterminate {
-        --background: var(--gray-xlight);
-        --color: var(--background);
+        --background: var(--color-empty);
+        --color: var(--color-empty);
     }
 }
 
@@ -89,8 +90,8 @@
         background: var(--error);
     }
     &:not([value]) {
-        --background: var(--gray-xlight);
-        --color: var(--background);
+        --background: var(--color-empty);
+        --color: var(--color-empty);
     }
 }
 /* Only firefox */

--- a/src/ProgressBar/style.css
+++ b/src/ProgressBar/style.css
@@ -46,8 +46,8 @@
     }
 
     &:indeterminate {
-        --color: var(--gray-xlight);
         --background: var(--gray-xlight);
+        --color: var(--background);
     }
 }
 
@@ -88,9 +88,9 @@
     &::-webkit-meter-even-less-good-value {
         background: var(--error);
     }
-    &:not(value) {
-        --color: var(--gray-xlight);
+    &:not([value]) {
         --background: var(--gray-xlight);
+        --color: var(--background);
     }
 }
 /* Only firefox */


### PR DESCRIPTION
This change adds support for `:indeterminate` state in the `ProgressBar` component (a kind of "empty state"). If the `ProgressBar` hasn't a `value` attribute, [it's indeterminate](https://developer.mozilla.org/es/docs/Web/CSS/:indeterminate), and looks like a gray bar like this:

<img width="440" alt="image" src="https://user-images.githubusercontent.com/377873/107973462-85d49f80-6fb5-11eb-9f3a-89c3d785ad1a.png">

In addition to that, I've refactored the css color variables to make it easier to override them. Now, this component has the following css variables:

```css
.ola_progressBar.custom {
    --color: red; /* The color for the value bar and the border */
    --background: blue; /* The color for the background */
    --color-empty: gray; /* The color for the indeterminate/empty state */
}
```

This makes easier to place this component over other backgrounds.
cc @twoixter 