### PR TITLE
fix js error when props onOpen or onClose aren't provided

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -33,7 +33,9 @@ const Tooltip = ({ variant, className, trigger, onOpen, onClose, children }) => 
 
 Tooltip.defaultProps = {
   variant: null,
-  className: null
+  className: null,
+  onOpen: () => false,
+  onClose: () => false
 }
 
 Tooltip.propTypes = {


### PR DESCRIPTION
I have a js error reported by Sentry related to Tooltip component:

<img width="708" alt="Captura de pantalla 2021-03-18 a las 15 47 38" src="https://user-images.githubusercontent.com/29247073/111645703-493cd380-8801-11eb-9301-dc3136a52652.png">

